### PR TITLE
Fix generating hyperrogue-music.txt

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,8 +13,7 @@ musicdir=$(datadir)/hyperrogue/music
 dist_music_DATA = music/hr3-caves.ogg music/hr3-desert.ogg music/hr3-hell.ogg music/hr3-jungle.ogg music/hr3-mirror.ogg music/hr3-rlyeh.ogg music/hr3-crossroads.ogg music/hr3-graveyard.ogg music/hr3-icyland.ogg music/hr3-laboratory.ogg music/hr3-motion.ogg
 
 music/hyperrogue-music.txt: hyperrogue
-	cp hyperrogue-music.txt music/hyperrogue-music.txt
-	sed -i 's+music+$(pkgdatadir)/music+g' music/hyperrogue-music.txt
+	sed 's+music+$(pkgdatadir)/music+g' <hyperrogue-music.txt >music/hyperrogue-music.txt
 
 # Langen binary rules
 noinst_PROGRAMS = langen


### PR DESCRIPTION
```sed -i``` is not portable. Use portable ```sed``` command instead to generated target file in one step