### PR TITLE
Added -std=c++11 flag to Makefile

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,7 @@ hyperrogue_SOURCES = hyper.cpp savepng.c
 
 # Some definitions used in graph.cpp
 hyperrogue_CPPFLAGS = -DFONTDESTDIR=\"$(pkgdatadir)/DejaVuSans-Bold.ttf\" -DMUSICDESTDIR=\"$(pkgdatadir)/hyperrogue-music.txt\" -DSOUNDDESTDIR=\"$(pkgdatadir)/sounds/\"
+hyperrogue_CPPFLAGS += -std=c++11
 
 # Musicdir
 musicdir=$(datadir)/hyperrogue/music


### PR DESCRIPTION
Project doesn't build on linux otherwise, spits out pages of error messages with a suggestion to enable the flag.