### PR TITLE
Update "Makefile.mac" to work for OS X with Homebrew.

### DIFF
--- a/Makefile.mac
+++ b/Makefile.mac
@@ -1,7 +1,32 @@
-# note: this Makefile for Mac is based on this post. I have no resources to test it myself.
-# http://groups.google.com/group/rec.games.roguelike.development/browse_thread/thread/9c02e09c0195dc16/3cbde3dc4a0b7e4e
+# This Makefile works for Mac OS X (Yosemite).
 #
-# You will also probably need to configure it yourself a bit to make it work.
+# Run "brew install sdl" to install SDL in /usr/local.
+# Run "brew install sdl_gfx".
+# Run "brew install sdl_mixer".
+# Run "brew install sdl_ttf".
+# Run "make -f Makefile.mac" to build HyperRogue as ./hyper.
 
-hyper: hyper.cpp graph.cpp hyperpoint.cpp geometry.cpp cell.cpp heptagon.cpp game.cpp polygons.cpp classes.cpp
-	g++ -m32 -I/sw/include hyper.cpp -L/sw/lib -lSDL -lSDLMain -lSDL_ttf -lSDL_gfx -framework AppKit -DMAC -O3
+CXXFLAGS += -std=c++11 -DMAC
+CXXFLAGS += -W -Wall -Wextra -pedantic
+CXXFLAGS += -Wno-format-pedantic -Wno-unused-parameter -Wno-char-subscripts -Wno-missing-field-initializers -Wno-vla-extension
+CXXFLAGS += ${EXTRA_CXXFLAGS}
+CXXFLAGS += -I/usr/local/include
+LDFLAGS += -L/usr/local/lib
+
+hyper: hyper.o
+	$(CXX) $(CXXFLAGS) hyper.o $(LDFLAGS) -lSDL -lSDLMain -lSDL_gfx -lSDL_mixer -lSDL_ttf -framework AppKit -framework OpenGL -o hyper
+
+hyper.o: *.cpp language-data.cpp
+	$(CXX) $(CXXFLAGS) -O2 -c hyper.cpp
+
+langen: langen.cpp
+	$(CXX) $(CXXFLAGS) -O0 -Wno-embedded-directive langen.cpp -o langen
+
+# Generation of language-data.cpp
+language-data.cpp: langen
+	./langen > language-data.cpp
+
+.PHONY: clean
+
+clean:
+	rm -f langen language-data.cpp hyper.o hyper

--- a/graph.cpp
+++ b/graph.cpp
@@ -3557,7 +3557,7 @@ void drawcell(cell *c, transmatrix V, int spinv, bool mirrored) {
       else if((c->land == laCaribbean || c->land == laOcean || c->land == laOceanWall || c->land == laWhirlpool))
         qfloor(c, Vf, shCloudFloor[ct6], darkena(fcol, fd, 0xFF));
 
-      else if((c->land == laKraken))
+      else if(c->land == laKraken)
         qfloor(c, Vf, shFullFloor[ct6], darkena(fcol, fd, 0xFF));
 
       else if(c->land == laLivefjord)

--- a/langen.cpp
+++ b/langen.cpp
@@ -362,7 +362,7 @@ int main() {
   
   printf("hashcode hashval = 0x%x;\n\n", hashval);
   
-  printf("sentence all_sentences[] = {\n", size(allsent));
+  printf("sentence all_sentences[] = {\n");
   
   for(map<hashcode,string>::iterator it = ms.begin(); it != ms.end(); it++) {
     string s = it->second;
@@ -374,7 +374,7 @@ int main() {
     }
   printf("  };\n\n");
 
-  printf("fullnoun all_nouns[] = {\n", size(allnouns));
+  printf("fullnoun all_nouns[] = {\n");
   
   for(map<hashcode,string>::iterator it = mn.begin(); it != mn.end(); it++) {
     string s = it->second;


### PR DESCRIPTION
And drive-by fixes for a couple of Xcode warnings in fa8078dc8b49d0705ff0f95be7bafd5d76d67ce6 — feel free to cherry-pick that one separately if you want it.

The original `Makefile.mac` was from circa 2011, so I claim that nobody should care about it anymore. :) But it would also be reasonable to keep the old `Makefile.mac` and add this one as `Makefile.osx` or something, if you want.