### PR TITLE
Yendor-related fixes

### DIFF
--- a/debug.cpp
+++ b/debug.cpp
@@ -185,6 +185,10 @@ bool applyCheat(char u, cell *c = NULL) {
       }
     cheater++; addMessage(XLAT("Collected the keys!"));
     }
+  if(u == 'Y'-64) {
+    yendor::collected(cwt.c);
+    cheater++;
+    }
   if(u == 'P') {
     items[itSavedPrincess]++;
     princess::saved = true;
@@ -319,7 +323,6 @@ void showCheatMenu() {
   dialog::addItem(XLAT("gain kills"), 'K');
   dialog::addItem(XLAT("Hyperstone Quest"), 'C');
   dialog::addItem(XLAT("summon orbs"), 'O');
-  dialog::addItem(XLAT("gain Orb of Yendor"), 'Y');
   dialog::addItem(XLAT("summon lots of treasure"), 'T'-64);
   dialog::addItem(XLAT("Safety (quick save)"), 'S');
   dialog::addItem(XLAT("Select the land ---"), 'L');
@@ -328,6 +331,7 @@ void showCheatMenu() {
   dialog::addItem(XLAT("deplete orb powers"), 'M');
   dialog::addItem(XLAT("save a Princess"), 'P');
   dialog::addItem(XLAT("unlock Orbs of Yendor"), 'Y');
+  dialog::addItem(XLAT("gain Orb of Yendor"), 'Y'-64);
   dialog::addItem(XLAT("switch ghost timer"), 'G'-64);
   dialog::addItem(XLAT("switch web display"), 'W'-64);
   dialog::addItem(XLAT("peaceful mode"), 'P'-64);

--- a/yendor.cpp
+++ b/yendor.cpp
@@ -488,7 +488,8 @@ namespace yendor {
       }
 
     dialog::addBreak(60);
-    dialog::addItem(XLAT("Return to the normal game"), '0');
+    if (yendor::on)
+      dialog::addItem(XLAT("Return to the normal game"), '0');
     dialog::addSelItem(XLAT(
       easy ? "Challenges do not get harder" : "Each challenge gets harder after each victory"),
       " " + XLAT(easy ? "easy" : "challenge"), '1');


### PR DESCRIPTION
This fixes two minor issues in Yendor-related menus.

The help text for "Yendor Challenge" in the special modes menu is actually more confusing than helpful IMHO. I'd rather it just give a short message "Gain an Orb of Yendor first to unlock this challenge!" instead of a page of text. I could submit a patch for that if you want.