### PR TITLE
Only apply -std=c++11 to C++ flags

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,7 @@ hyperrogue_SOURCES = hyper.cpp savepng.c
 
 # Some definitions used in graph.cpp
 hyperrogue_CPPFLAGS = -DFONTDESTDIR=\"$(pkgdatadir)/DejaVuSans-Bold.ttf\" -DMUSICDESTDIR=\"$(pkgdatadir)/hyperrogue-music.txt\" -DSOUNDDESTDIR=\"$(pkgdatadir)/sounds/\"
-hyperrogue_CPPFLAGS += -std=c++11
+hyperrogue_CXXFLAGS = -std=c++11
 
 # Musicdir
 musicdir=$(datadir)/hyperrogue/music


### PR DESCRIPTION
CPPFLAGS are applied to both .cpp and .c files, and that breaks clang build:

error: invalid argument '-std=c++11' not allowed with 'C/ObjC'