### PR TITLE
Unswap the arguments to handleKeyFile(), and nits

### DIFF
--- a/game.cpp
+++ b/game.cpp
@@ -3465,7 +3465,7 @@ int pickDownDirection(cell *c, flagtype mf) {
   }
 
 template<class T> 
-cell *determinePush(cellwalker who, cell *c2, int subdir, T valid) {
+cell *determinePush(cellwalker who, cell *c2, int subdir, const T& valid) {
   cellwalker push = who;
   cwstep(push);
   cwspin(push, 3 * -subdir);
@@ -7062,4 +7062,3 @@ bool warningprotection() {
   items[itWarning] = 1;
   return true;
   }
-

--- a/hyper.h
+++ b/hyper.h
@@ -1293,8 +1293,6 @@ void pushThumper(cell *th, cell *cto);
 template<class T> T pick(T x, T y) { return hrand(2) ? x : y; }
 template<class T> T pick(T x, T y, T z) { switch(hrand(3)) { case 0: return x; case 1: return y; case 2: return z; } return x; }
 template<class T> T pick(T x, T y, T z, T v) { switch(hrand(4)) { case 0: return x; case 1: return y; case 2: return z; case 3: return v; } return x; }
-template<class T, class... U> bool among(T x, T y) { return x == y; }
-template<class T, class... U> bool among(T x, T y, U... u) { return x==y || among(x,u...); }
 
 eLand getNewSealand(eLand old);
 bool createOnSea(eLand old);

--- a/mapeditor.cpp
+++ b/mapeditor.cpp
@@ -27,7 +27,7 @@ namespace mapeditor {
   map<int, cell*> modelcell;
 
   void handleKeyMap(int sym, int uni);
-  bool handleKeyFile(int sym, int uni);
+  void handleKeyFile(int sym, int uni);
 
   void applyModelcell(cell *c) {
     if(mapeditor::whichPattern == 'H') return;
@@ -1085,17 +1085,17 @@ namespace mapeditor {
       }
     }
   
-  bool handleKeyFile(int uni, int sym) {
+  void handleKeyFile(int sym, int uni) {
     string& s(*cfileptr);
     int i = size(s) - (editext?0:4);
     if(uni > 2000) sym = uni - 2000;
     if(sym == SDLK_RETURN || sym == SDLK_KP_ENTER || sym == SDLK_ESCAPE) {
       popScreen();
-      return true;
+      return;
       }
     else if(sym == SDLK_F2 || sym == SDLK_F3) {
       popScreen();
-      return false;
+      return;
       }
     else if(sym == SDLK_F4) {
       editext = !editext;
@@ -1125,7 +1125,6 @@ namespace mapeditor {
       else
         s = where + v[i].first;
       }
-    return true;
     }
   
   void handleKeyMap(int sym, int uni) {

--- a/rogueviz.cpp
+++ b/rogueviz.cpp
@@ -1801,7 +1801,8 @@ string cname() {
   return "coord-67.txt";
   }
 
-template<class T> function<void(presmode)> roguevizslide(char c, T t) {
+template<class T>
+function<void(presmode)> roguevizslide(char c, const T& t) {
   return [c,t] (presmode mode) {
     mapeditor::canvasback = 0x101010;
     setCanvas(mode, c);
@@ -1819,7 +1820,8 @@ template<class T> function<void(presmode)> roguevizslide(char c, T t) {
     };
   }
 
-template<class T, class T1> function<void(presmode)> roguevizslide_action(char c, T t, T1 act) {
+template<class T, class U>
+function<void(presmode)> roguevizslide_action(char c, const T& t, const U& act) {
   return [c,t,act] (presmode mode) {
     mapeditor::canvasback = 0x101010;
     setCanvas(mode, c);


### PR DESCRIPTION
commit 5fdbe905824495b8813fa4027482403de0868ba6

    Unswap the arguments to handleKeyFile()
    And its return value was never used, so get rid of it.
    Fixes #23.

commit 139226f68d328c098270661c3a023ec485a1a181

    Nit: Pass some lambdas to functions by reference, not by value.
    And remove an unemployed variadic `among()` template.
    No functional change.

Fixes #23.