### PR TITLE
Pushing a thumper through a boat is no longer allowed.

### DIFF
--- a/game.cpp
+++ b/game.cpp
@@ -6270,7 +6270,7 @@ void pushThumper(cell *th, cell *cto) {
   }
 
 bool canPushThumperOn(cell *tgt, cell *thumper, cell *player) {
-  if(tgt->wall == waBoat) return false;
+  if(tgt->wall == waBoat || tgt->wall == waStrandedBoat) return false;
   if(isReptile(tgt->wall)) return false;
   if(isWatery(tgt) && !tgt->monst)
     return true;


### PR DESCRIPTION
The old behavior was that you could push a thumper onto a stranded boat, which would destroy the stranded boat.