### PR TITLE
Minor fixes for Mac and MinGW.

### DIFF
--- a/Makefile.mac
+++ b/Makefile.mac
@@ -1,4 +1,4 @@
-# This Makefile works for Mac OS X (Yosemite).
+# This Makefile works for Mac OS X (El Capitan).
 #
 # Run "brew install sdl" to install SDL in /usr/local.
 # Run "brew install sdl_gfx".
@@ -7,15 +7,31 @@
 # Run "make -f Makefile.mac" to build HyperRogue as ./hyper.
 
 CXXFLAGS += -std=c++11 -march=native -DMAC
-# CXXFLAGS += -DCAP_ROGUEVIZ
 CXXFLAGS += -W -Wall -Wextra -pedantic
-CXXFLAGS += -Wno-format-pedantic -Wno-unused-parameter -Wno-char-subscripts -Wno-missing-field-initializers -Wno-vla-extension
-CXXFLAGS += ${EXTRA_CXXFLAGS}
+CXXFLAGS += -Wno-format-pedantic -Wno-unused-parameter -Wno-missing-field-initializers -Wno-vla-extension
 CXXFLAGS += -I/usr/local/include
+CXXFLAGS += ${EXTRA_CXXFLAGS}
+
 LDFLAGS += -L/usr/local/lib
 
-hyper: hyper.o
-	$(CXX) $(CXXFLAGS) hyper.o $(LDFLAGS) -lSDL -lSDLMain -lSDL_gfx -lSDL_mixer -lSDL_ttf -framework AppKit -framework OpenGL -o hyper
+OBJS = hyper.o
+
+ifeq (a,b)
+# Enable PNG screenshots. Requires "brew install libpng".
+CXXFLAGS += -DCAP_PNG
+LDFLAGS += -lpng
+OBJS += savepng.o
+else
+CXXFLAGS += -DCAP_PNG=0
+endif
+
+ifeq (a,b)
+# Enable RogueViz.
+CXXFLAGS += -DCAP_ROGUEVIZ
+endif
+
+hyper: $(OBJS)
+	$(CXX) $(CXXFLAGS) $(OBJS) $(LDFLAGS) -lSDL -lSDLMain -lSDL_gfx -lSDL_mixer -lSDL_ttf -framework AppKit -framework OpenGL -o hyper
 
 hyper.o: *.cpp language-data.cpp
 	$(CXX) $(CXXFLAGS) -O2 -c hyper.cpp
@@ -23,11 +39,13 @@ hyper.o: *.cpp language-data.cpp
 langen: langen.cpp language-??.cpp language-ptbr.cpp
 	$(CXX) $(CXXFLAGS) -O0 -Wno-embedded-directive langen.cpp -o langen
 
-# Generation of language-data.cpp
 language-data.cpp: langen
 	./langen > language-data.cpp
+
+savepng.o: savepng.cpp
+	$(CXX) $(CXXFLAGS) -O2 -c savepng.cpp
 
 .PHONY: clean
 
 clean:
-	rm -f langen language-data.cpp hyper.o hyper
+	rm -f hyper hyper.o langen language-data.cpp savepng.o

--- a/Makefile.mgw
+++ b/Makefile.mgw
@@ -7,11 +7,26 @@
 
 CXXFLAGS += -std=c++11 -mwindows -DWINDOWS
 CXXFLAGS += -D_A_VOLID=8
-CXXFLAGS += -DCAP_PNG=0
 CXXFLAGS += ${EXTRA_CXXFLAGS}
 
-hyper.exe: hyper.obj hyper.res
-	$(CXX) $(CXXFLAGS) hyper.obj hyper.res -lSDL -lSDL_mixer -lopengl32 -lSDL_ttf -lSDL_gfx -lglew32 -o hyper.exe
+OBJS = hyper.obj
+
+ifeq (a,b)
+# Enable PNG screenshots. Requires libpng.
+CXXFLAGS += -DCAP_PNG
+LDFLAGS += -lpng
+OBJS += savepng.obj
+else
+CXXFLAGS += -DCAP_PNG=0
+endif
+
+ifeq (a,b)
+# Enable RogueViz.
+CXXFLAGS += -DCAP_ROGUEVIZ
+endif
+
+hyper.exe: $(OBJS) hyper.res
+	$(CXX) $(CXXFLAGS) $(OBJS) hyper.res -lSDL -lSDL_mixer -lopengl32 -lSDL_ttf -lSDL_gfx -lglew32 -o hyper.exe
 
 hyper.obj: *.cpp language-data.cpp hyper.res
 	$(CXX) $(CXXFLAGS) -O2 -c hyper.cpp -o hyper.obj
@@ -25,7 +40,10 @@ langen.exe: langen.cpp language-??.cpp language-ptbr.cpp
 language-data.cpp: langen.exe
 	./langen.exe > language-data.cpp
 
+savepng.obj: savepng.cpp
+	$(CXX) $(CXXFLAGS) -O2 -c savepng.cpp -o savepng.obj
+
 .PHONY: clean
 
 clean:
-	rm -f langen.exe language-data.cpp hyper.obj hyper.res hyper.exe
+	rm -f hyper.exe hyper.obj hyper.res langen.exe language-data.cpp savepng.obj 

--- a/fieldpattern.cpp
+++ b/fieldpattern.cpp
@@ -754,7 +754,8 @@ void nextPrime(fgeomextra& ex) {
     fp.Prime = nextprime;
     if(fp.solve() == 0) {
       fp.build();
-      ex.primes.emplace_back(primeinfo{nextprime, size(fp.matrices) / S7, (bool) fp.wsquare});
+      int cells = fp.matrices.size() / S7;
+      ex.primes.emplace_back(primeinfo{nextprime, cells, (bool) fp.wsquare});
       break;
       }
     nextprime++;

--- a/hyper.h
+++ b/hyper.h
@@ -6,6 +6,8 @@
 #define VERNUM 10402
 #define VERNUM_HEX 0xA0B2
 
+#include <stdarg.h>
+
 namespace hr {
 
 using namespace std;
@@ -368,7 +370,7 @@ string its(int i);
 int hrand(int i);
 
 #ifndef STDSIZE
-template<class T> int size(const T& x) {return int(x.size()); }
+template<class T> int size(const T& x) {return x.size(); }
 #endif
 
 // initialize the achievement system.
@@ -3432,7 +3434,15 @@ int score_default(int id);
 void handle_event(SDL_Event& ev);
 
 #ifndef XPRINTF
-template<class...T> void Xprintf(const char *fmt, T... t) { printf(fmt, t...); }
+#ifdef __GNUC__
+__attribute__((__format__ (__printf__, 1, 2)))
+#endif
+void Xprintf(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    vprintf(fmt, ap);
+    va_end(ap);
+}
 #endif
 
 void pop_game();

--- a/langen.cpp
+++ b/langen.cpp
@@ -14,7 +14,9 @@
 #include <stdlib.h>
 using namespace std;
 
-template<class T> int size(T x) { return x.size(); }
+#ifndef STDSIZE
+template<class T> int size(const T& x) { return x.size(); }
+#endif
 
 #define NUMLAN 7
 

--- a/rogueviz-video.cpp
+++ b/rogueviz-video.cpp
@@ -23,7 +23,7 @@ void rvvideo(const string &fname) {
         reached = (2*reached-1) / 3;
       else reached *= 2;
       }
-    printf("reached = %Ld\n", reached);
+    printf("reached = %lld\n", reached);
     vector<string> seq;
     while(reached>1) { 
       seq.push_back(llts(reached));

--- a/savepng.cpp
+++ b/savepng.cpp
@@ -35,6 +35,9 @@ static void png_write_SDL(png_structp png_ptr, png_bytep data, png_size_t length
 	SDL_RWwrite(rw, data, sizeof(png_byte), length);
 }
 
+#ifdef __cplusplus
+extern "C"
+#endif
 SDL_Surface *SDL_PNGFormatAlpha(SDL_Surface *src) 
 {
 	SDL_Surface *surf;
@@ -56,6 +59,9 @@ SDL_Surface *SDL_PNGFormatAlpha(SDL_Surface *src)
 	return surf;
 }
 
+#ifdef __cplusplus
+extern "C"
+#endif
 int SDL_SavePNG_RW(SDL_Surface *surface, SDL_RWops *dst, int freedst) 
 {
 	png_structp png_ptr;

--- a/sysconfig.h
+++ b/sysconfig.h
@@ -88,7 +88,7 @@
 #define CAP_SDL (!ISMOBILE)
 #endif
 
-#ifdef CAP_COMPASS
+#ifndef CAP_COMPASS
 #define CAP_COMPASS ISMOBILE
 #endif
 


### PR DESCRIPTION
Eliminate a format-string warning by using less template magic:
https://stackoverflow.com/questions/12573968/how-to-use-gccs-printf-format-attribute-with-c11-variadic-templates

Fix one `%Ld` in `rogueviz.cpp` that should have been `%lld`.

Rename `savepng.c` into `savepng.cpp` so that we don't have to care about the system's C compiler; it builds fine using the same C++ options as HyperRogue itself.

Figure out how to get `-DCAP_PNG` and `-DCAP_ROGUEVIZ` working on Mac, and document them.
Assume that roughly the same things should also work on MinGW.

Consistency on `STDSIZE`. The one place where Clang still complains even with `-std=c++17 -DSTDSIZE -Wno-sign-compare` is here:

    ./fieldpattern.cpp:757:51: error: non-constant-expression cannot be narrowed from type 'unsigned long' to 'int' in initializer list
          [-Wc++11-narrowing]
          ex.primes.emplace_back(primeinfo{nextprime, size(fp.matrices) / S7, (bool) fp.wsquare});
                                                      ^~~~~~~~~~~~~~~~~~~~~~

So, we fix that up too, in this patch.