### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ script:
   - ./configure
   - make
   - sudo make install
+  - ./hyperrogue --help

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: cpp
+sudo: required
+addons:
+  apt:
+    packages:
+      - libsdl-dev
+      - libsdl-mixer1.2-dev
+      - libsdl-gfx1.2-dev
+      - libsdl-ttf2.0-dev
+      - libglew-dev
+compiler:
+  - gcc
+  - clang
+script:
+  - autoreconf -fiv
+  - ./configure
+  - make
+  - sudo make install

--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,7 @@ dist_sounds_DATA = sounds/*
 noinst_PROGRAMS = langen
 langen_SOURCES = langen.cpp 
 # Disable optimization, not needed
-langen_CXXFLAGS = -O0
+langen_CXXFLAGS = -O0 -std=c++11
 
 # Generation of language-data.cpp
 language-data.cpp: langen


### PR DESCRIPTION
Also set C++11 standard for landgen, which fixes build on Travis (likely because it uses older compiler which doesn't enable c++11 by default).

Build results: https://travis-ci.org/AMDmi3/hyperrogue