### PR TITLE
[ISSUE IN THE FORM OF A PATCH] MSVC warns about bool/int conversion

### DIFF
--- a/graph.cpp
+++ b/graph.cpp
@@ -3461,7 +3461,7 @@ void drawcell(cell *c, transmatrix V, int spinv, bool mirrored) {
 
   // if(behindsphere(V)) return;
   
-  if(callhandlers(0, hooks_drawcell, c, V)) return;
+  if(callhandlers(false, hooks_drawcell, c, V)) return;
   
   ld dist0 = hdist0(tC0(V)) - 1e-6;
   if(dist0 < geom3::highdetail) detaillevel = 2;

--- a/heptagon.cpp
+++ b/heptagon.cpp
@@ -198,7 +198,7 @@ heptspin operator + (const heptspin& hs, wstep_t) {
   createStep(hs.h, hs.spin);
   heptspin res;
   res.h = hs.h->move[hs.spin];
-  res.mirrored = hs.mirrored ^ hs.h->mirror(hs.spin);
+  res.mirrored = boolean_xor(hs.mirrored, hs.h->mirror(hs.spin));
   res.spin = hs.h->spin(hs.spin);
   return res;
   }

--- a/hyper.h
+++ b/hyper.h
@@ -421,6 +421,8 @@ int hrand(int i);
 // size casted to int, to prevent warnings and actual errors caused by the unsignedness of x.size()
 template<class T> int isize(const T& x) {return x.size(); }
 
+bool boolean_xor(bool a, bool b) { return a ^ b; }
+
 // initialize the achievement system.
 void achievement_init();
 

--- a/hypgraph.cpp
+++ b/hypgraph.cpp
@@ -580,7 +580,7 @@ void drawrec(const heptspin& hs, hstate s, const transmatrix& V) {
       if(c->mov[ds] && c->spn(ds) == 0 && dodrawcell(c->mov[ds])) {
         transmatrix V2 = V1 * hexmove[d];
         if(in_qrange(V2))
-        drawcell(c->mov[ds], V2, 0, hs.mirrored ^ c->mirror(ds));
+        drawcell(c->mov[ds], V2, 0, boolean_xor(hs.mirrored, c->mirror(ds)));
         }
       }
     }

--- a/mapeditor.cpp
+++ b/mapeditor.cpp
@@ -1322,7 +1322,7 @@ namespace mapeditor {
       fscanf(f, "%d%d%d%d\n", &tg, &nt, &wp, &patterns::subpattern_flags);
       patterns::whichPattern = wp;
       if(tg != geometry) { targetgeometry = eGeometry(tg); stop_game_and_switch_mode(rg::geometry); }
-      if(nt != nonbitrunc) stop_game_and_switch_mode(rg::bitrunc);
+      if(boolean_xor(nt, nonbitrunc)) stop_game_and_switch_mode(rg::bitrunc);
       start_game();
       }
 
@@ -1767,7 +1767,7 @@ namespace mapeditor {
               if(gstate == 1) queueline(lpsm, P2, 0x90000080), gstate = 0;
               if(ti == ew.pointid) {
                 queueline(pseudomouse, P2, 0xF0000080);
-                if(ew.side == b) queueline(pseudomouse, Plast, 0x90000080);
+                if(int(ew.side) == b) queueline(pseudomouse, Plast, 0x90000080);
                 else gstate = 1, lpsm = pseudomouse;
                 }
               }

--- a/pattern2.cpp
+++ b/pattern2.cpp
@@ -624,7 +624,7 @@ namespace patterns {
       int sp = c->spin(0);
       if(gp::on) {
         sp = gp::last_dir(c);
-        sp ^= ishex2(c);
+        sp = boolean_xor(sp, ishex2(c));
         }
       if(geometry == gBolza2 && (!gp::on || gp_threecolor() == 2)) {
         patterninfo si0;
@@ -666,7 +666,7 @@ namespace patterns {
             int sp2 = c2->spin(0);
             if(gp::on) {
               sp2 = gp::last_dir(c2);
-              sp2 ^= ishex2(c2);
+              sp2 = boolean_xor(sp2, ishex2(c2));
               }
             id2 = 8 * ((c2->master->fiftyval & 1) ^ (sp2 & 1));
             }


### PR DESCRIPTION
This patch does, technically, fix the following MSVC diagnostics.
But I believe that it should *not* be committed exactly as-is.
I suspect that some of these diagnostics — especially the ones in `mapeditor.cpp` — might indicate possible bugs or at least tech debt. Committing this patch as-is would just make the bug/debt harder to find in the future. So I'd be happier if you left this PR open until each instance is fixed in some "good" way, and then closed this PR without merging it.

There is also a trivial workaround for MSVC: I can just pass `/wd4805`, the same way I pass `-Wno-unused-result` on GCC.

    heptagon.cpp(201): warning C4805: '^': unsafe mix of type 'const bool' and type 'int' in operation
    pattern2.cpp(627): warning C4805: '^=': unsafe mix of type 'int' and type 'bool' in operation
    pattern2.cpp(669): warning C4805: '^=': unsafe mix of type 'int' and type 'bool' in operation
    mapeditor.cpp(1325): warning C4805: '!=': unsafe mix of type 'int' and type 'bool' in operation
    mapeditor.cpp(1770): warning C4805: '==': unsafe mix of type 'bool' and type 'int' in operation
    hypgraph.cpp(583): warning C4805: '^': unsafe mix of type 'const bool' and type 'int' in operation
    hyper.h(2025): warning C4805: '!=': unsafe mix of type 'bool' and type 'int' in operation
    graph.cpp(3464): note: see reference to function template instantiation 'V hr::callhandlers<bool(hr::cell *,const hr::transmatrix &),int,hr::cell*,hr::transmatrix>(V,hr::hookset<bool (hr::cell *,const hr::transmatrix &)> *,hr::cell *&,hr::transmatrix &)' being compiled with [V=int]