### PR TITLE
Replace std::function with hyper_function for a 37% speedup in compile time

### DIFF
--- a/dialogs.cpp
+++ b/dialogs.cpp
@@ -473,7 +473,7 @@ namespace dialog {
   
   color_t *colorPointer;
   
-  bool handleKeyColor(int sym, int uni) {
+  void handleKeyColor(int sym, int uni) {
     unsigned& color = *colorPointer;
     int shift = colorAlpha ? 0 : 8;
 
@@ -514,7 +514,6 @@ namespace dialog {
     else if(doexiton(sym, uni)) {
       popScreen();
       }
-    return false;
     }
   
   bool colorAlpha;

--- a/graph.cpp
+++ b/graph.cpp
@@ -1840,9 +1840,9 @@ int taildist(cell *c) {
   }
 
 int last_wormsegment = -1;
-vector<vector< std::function<void()> > > wormsegments;
+vector<vector< function<void()> > > wormsegments;
 
-void add_segment(int d, const std::function<void()>& s) {
+void add_segment(int d, const function<void()>& s) {
   if(isize(wormsegments) <= d) wormsegments.resize(d+1);
   last_wormsegment = max(last_wormsegment, d);
   wormsegments[d].push_back(s);
@@ -5727,7 +5727,7 @@ void drawscreen() {
   mouseovers = " ";
 
   cmode = 0;
-  keyhandler = [] (int sym, int uni) { return false; };
+  keyhandler = [] (int sym, int uni) {};
   #if CAP_SDL
   joyhandler = [] (SDL_Event& ev) { return false; };
   #endif

--- a/hyper.h
+++ b/hyper.h
@@ -7,6 +7,7 @@
 #define VERNUM_HEX 0xA504
 
 #include <stdarg.h>
+#include "hyper_function.h"
 
 namespace hr {
 
@@ -14,6 +15,8 @@ template<class T>
 void ignore(T&&) {
   // placate GCC's overzealous -Wunused-result
   }
+
+template<class Sig> using function = hyper_function<Sig>;
 
 // functions and types used from the standard library
 using std::vector;
@@ -24,7 +27,6 @@ using std::sort;
 using std::multimap;
 using std::set;
 using std::string;
-using std::function;
 using std::pair;
 using std::tuple;
 using std::shared_ptr;

--- a/hyper_function.h
+++ b/hyper_function.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+template<class Sig>
+class hyper_function;
+
+template<class R, class... Args>
+struct hyper_function_state_base {
+    virtual R call(Args...) const = 0;
+    virtual hyper_function_state_base *clone() const = 0;
+    virtual ~hyper_function_state_base() = default;
+};
+
+template<class T, class R, class... Args>
+struct hyper_function_state : hyper_function_state_base<R, Args...> {
+    using Self = hyper_function_state<T, R, Args...>;
+    T t_;
+    explicit hyper_function_state(T t) : t_(std::move(t)) {}
+    R call(Args... args) const override {
+        return const_cast<T&>(t_)(static_cast<Args&&>(args)...);
+    }
+    hyper_function_state_base<R, Args...> *clone() const override {
+        return new Self(*this);
+    }
+};
+
+template<class R, class... Args>
+class hyper_function<R(Args...)>
+{
+    hyper_function_state_base<R, Args...> *ptr_ = nullptr;
+public:
+    hyper_function() = default;
+
+    template<class Callable, class = decltype(R(std::declval<typename std::decay<Callable>::type>()(std::declval<Args>()...)))>
+    hyper_function(Callable&& t) :
+        ptr_(new hyper_function_state<typename std::decay<Callable>::type, R, Args...>(static_cast<Callable&&>(t)))
+    {}
+
+    ~hyper_function() {
+        delete ptr_;
+    }
+
+    hyper_function(hyper_function& rhs) : ptr_(rhs.ptr_ ? rhs.ptr_->clone() : nullptr) {}
+    hyper_function(const hyper_function& rhs) : ptr_(rhs.ptr_ ? rhs.ptr_->clone() : nullptr) {}
+    hyper_function(hyper_function&& rhs) noexcept : ptr_(rhs.ptr_) { rhs.ptr_ = nullptr; }
+    hyper_function(const hyper_function&& rhs) = delete;
+
+    void operator=(hyper_function rhs) noexcept {
+        std::swap(ptr_, rhs.ptr_);
+    }
+
+    R operator()(Args... args) const {
+        return ptr_->call(static_cast<Args&&>(args)...);
+    }
+
+    explicit operator bool() const noexcept {
+        return ptr_ != nullptr;
+    }
+};

--- a/rogueviz-banachtarski.cpp
+++ b/rogueviz-banachtarski.cpp
@@ -442,7 +442,7 @@ void bantar_anim() {
 
 bool bmap;
 
-bool bantar_stats() {
+void bantar_stats() {
   if(bmap) {
     vid.linewidth *= (inHighQual ? 10 : 2);
     for(auto p: parent) if(gmatrix.count(p.first) && gmatrix.count(p.second))
@@ -458,7 +458,6 @@ bool bantar_stats() {
     vid.linewidth /= (inHighQual ? 10 : 2);
     drawqueue();
     }
-  return false;
   }
 
 void init_bantar() {

--- a/rogueviz-graph.cpp
+++ b/rogueviz-graph.cpp
@@ -389,7 +389,7 @@ void show_graph() {
     };
   }
 
-bool frame() { 
+void frame() { 
   if(graphcolor) {
     hyperpoint h0 = find_point(0);
     hyperpoint h1 = find_point(1);
@@ -397,7 +397,6 @@ bool frame() {
     draw_to(0, h0, 1, h1);
     finish();
     }
-  return false;
   }
 
 #if CAP_COMMANDLINE  


### PR DESCRIPTION
commit f6f96e1129df134a9921015dc6e59d45ce5a7e11

    Fix some minor std::function-related bugs.
    
    Lambdas to be stored in `function<void()>` should not return `bool`.
    
    Two uses of `std::function` could be just `function`, like everywhere
    else in the codebase.

commit 4b3b2fd15c7cfc1be3202e290eff3b654d829fae

    Replace std::function with hyper_function for a 37% speedup in compile time.
    
    Before:
    
        time c++ -O2 -DMAC -I/usr/local/include -std=c++11 -march=native
                 -W -Wall -Wextra -Werror -pedantic -Wno-format-pedantic
                 -Wno-missing-field-initializers -Wno-unused-parameter
                 -DCAP_GLEW=0 -DCAP_PNG=0    -c hyper.cpp -o hyper.o
    
        real 2m22.508s
        user 2m20.625s
        sys  0m1.648s
    
    After:
    
        time c++ -O2 -DMAC -I/usr/local/include -std=c++11 -march=native
                 -W -Wall -Wextra -Werror -pedantic -Wno-format-pedantic
                 -Wno-missing-field-initializers -Wno-unused-parameter
                 -DCAP_GLEW=0 -DCAP_PNG=0    -c hyper.cpp -o hyper.o
    
        real 1m30.515s
        user 1m29.793s
        sys  0m0.689s
    
    Comparing object file size:
    
        -rw-r--r--  1 ajo  staff  8215036 Jan  5 20:46 old-hyper.o
        -rw-r--r--  1 ajo  staff  7547232 Jan  5 20:47 new-hyper.o
    
    Comparing number of symbols:
    
        nm old-hyper.o | wc -l  => 12590
        nm new-hyper.o | wc -l  =>  9742
    
    No appreciable difference in link time; the linker takes less than
    half a second in either case.