### PR TITLE
Add -Wimplicit-fallthrough

### DIFF
--- a/Makefile.simple
+++ b/Makefile.simple
@@ -82,22 +82,22 @@ endif
 ifeq (${TOOLCHAIN},clang)
   CXXFLAGS_STD = -std=c++11
   CXXFLAGS_EARLY += -march=native -fPIC
-  CXXFLAGS_EARLY += -W -Wall -Wextra -Werror -pedantic
-  CXXFLAGS_EARLY += -Wno-unused-parameter -Wno-implicit-fallthrough -Wno-maybe-uninitialized -Wno-unknown-warning-option
+  CXXFLAGS_EARLY += -W -Wall -Wextra -Wimplicit-fallthrough -Werror -pedantic
+  CXXFLAGS_EARLY += -Wno-unused-parameter -Wno-maybe-uninitialized -Wno-unknown-warning-option
 endif
 
 ifeq (${TOOLCHAIN},gcc)
   CXXFLAGS_STD = -std=c++11
   CXXFLAGS_EARLY += -march=native -fPIC
   CXXFLAGS_EARLY += -W -Wall -Wextra -Werror -pedantic
-  CXXFLAGS_EARLY += -Wno-unused-parameter -Wno-implicit-fallthrough -Wno-maybe-uninitialized
+  CXXFLAGS_EARLY += -Wno-unused-parameter -Wno-maybe-uninitialized
 endif
 
 ifeq (${TOOLCHAIN},mingw)
   CXXFLAGS_STD = -std=c++11
   CXXFLAGS_EARLY += -march=native
   CXXFLAGS_EARLY += -W -Wall -Wextra -Werror
-  CXXFLAGS_EARLY += -Wno-unused-parameter -Wno-implicit-fallthrough -Wno-maybe-uninitialized
+  CXXFLAGS_EARLY += -Wno-unused-parameter -Wno-maybe-uninitialized
 endif
 
 

--- a/binary-tiling.cpp
+++ b/binary-tiling.cpp
@@ -284,6 +284,7 @@ EX namespace bt {
               else
                 return path(h, 4, 2, {3, 4, 1});
             }
+          break;
           }
         case gTernary: {
           switch(d) {
@@ -302,6 +303,7 @@ EX namespace bt {
               else
                 return path(h, 5, 3, {4, 5, 2});
             }
+          break;
           }
         #if MAXMDIM >= 4         
         case gBinary3: {
@@ -336,6 +338,7 @@ EX namespace bt {
               else
                 return path(h, 7, 6, {8, 7, parent->c.spin(8) ^ 2});
             }
+          break;
           }
         case gHoroRec: {
           switch(d) {
@@ -362,6 +365,7 @@ EX namespace bt {
               parent->cmove(6);
               return path(h, 5, 3, {6, 2, parent->c.spin(6)});
             }
+          break;
           }
         case gHoroTris: {            
           switch(d) {
@@ -376,6 +380,7 @@ EX namespace bt {
               else if(s == d-3) return path(h, d, d, {7, 0});
               else return path(h, d, d, {7, d, 9-d-s});
             }
+          break;
           }
         case gHoroHex: {
           // the comment is a picture...
@@ -409,8 +414,9 @@ EX namespace bt {
               return path(h, 12, (z+1)%3+3, {13, z+6});
             }
           }
+          break;
         #endif
-        default: ;
+        default: break;
         }
       printf("error: case not handled in binary tiling\n");
       breakhere();
@@ -470,6 +476,8 @@ EX namespace bt {
             add(-2 * t0 + shift1);
             }
           }
+          // WARNING! UNINTENTIONAL FALLTHROUGH??
+          goto fallthru; fallthru:
         case gHoroRec: {
           ld r2 = sqrt(2);
           for(int y=-1; y<=1; y++) for(int x=-1; x<=1; x+=2) for(int z=-1; z<=1; z++)

--- a/celldrawer.cpp
+++ b/celldrawer.cpp
@@ -533,14 +533,14 @@ void celldrawer::setcolors() {
         wcol = fcol;  
       break;
 
-    case waMineUnknown: case waMineMine: 
-      if(mine::marked_safe(c))
-        fcol = wcol = gradient(wcol, 0x40FF40, 0, 0.2, 1);
+    case waMineUnknown: case waMineMine: case waMineOpen:
+      if(c->wall == waMineOpen)
+        ;
+      else if(mine::marked_safe(c))
+        wcol = gradient(wcol, 0x40FF40, 0, 0.2, 1);
       else if(mine::marked_mine(c))
-        fcol = wcol = gradient(wcol, 0xFF4040, -1, sintick(100), 1);
-      // fallthrough
+        wcol = gradient(wcol, 0xFF4040, -1, sintick(100), 1);
 
-    case waMineOpen:
       if(wmblack || wmascii) {
         wcol &= 0xFEFEFE;
         wcol >>= 1;
@@ -555,6 +555,7 @@ void celldrawer::setcolors() {
     case waEditStatue:
       if(c->land == laCanvas) wcol = c->landparam;
       else wcol = (0x125628 * c->wparam) & 0xFFFFFF;
+      break;
   
     default:
       break;    
@@ -1382,11 +1383,8 @@ void celldrawer::draw_features() {
       break;
       }
     
-    case waTrapdoor:
-      if(c->land == laZebra) break;
-      /* fallthrough */
-    
-    case waClosePlate: case waOpenPlate: {
+    case waTrapdoor: case waClosePlate: case waOpenPlate: {
+      if (c->wall == waTrapdoor && c->land == laZebra) break;
       shiftmatrix V2 = V;
       if(wmescher && geosupport_football() == 2 && pseudohept(c) && c->land == laPalace) V2 = V * spin(M_PI / c->type);
       if(GDIM == 3) {

--- a/expansion.cpp
+++ b/expansion.cpp
@@ -577,8 +577,9 @@ void celldrawer::do_viewdist() {
         celldistance(c, distance_from == dfPlayer ? cwt.at : currentmap->gamestart());
       dc = (d != cd) ? 0xFF0000 : 0x00FF00;
       label = its(d);
+      break;
       }
-    case ncNone: ;
+    case ncNone: break;
     }
 
   // string label = its(fieldpattern::getriverdistleft(c)) + its(fieldpattern::getriverdistright(c));

--- a/hypgraph.cpp
+++ b/hypgraph.cpp
@@ -1072,6 +1072,7 @@ EX void apply_other_model(shiftpoint H_orig, hyperpoint& ret, eModel md) {
         if(pconf.skiprope) 
           ret = mobius(ret, pconf.skiprope, 1);
         }
+      break;
       }
     
     case mdGUARD: case mdManual: break;
@@ -1909,7 +1910,10 @@ EX void draw_model_elements() {
         }
 
       queuereset(pmodel, PPR::CIRCLE);
-      /* fallthrough */
+      ld a = -pconf.model_orientation * degree;
+      queuestr(shiftless(xspinpush0(a, +pconf.twopoint_param)), vid.xres / 100, "X", ringcolor >> 8);
+      queuestr(shiftless(xspinpush0(a, -pconf.twopoint_param)), vid.xres / 100, "X", ringcolor >> 8);
+      return;
       }
 
     case mdTwoPoint: case mdSimulatedPerspective: {

--- a/mymake.cpp
+++ b/mymake.cpp
@@ -36,7 +36,7 @@ bool mingw64 = false;
 
 void set_linux() {
   preprocessor = "g++ -E";
-  compiler = "g++ -Wall -Wextra -Wno-maybe-uninitialized -Wno-unused-parameter -Wno-implicit-fallthrough -rdynamic -fdiagnostics-color=always -c";
+  compiler = "g++ -Wall -Wextra -Wno-maybe-uninitialized -Wno-unused-parameter -rdynamic -fdiagnostics-color=always -c";
   linker = "g++ -rdynamic -o hyper";
   opts = "-DFHS -DLINUX -I/usr/include/SDL";
   libs = " savepng.o -lSDL -lSDL_ttf -lSDL_mixer -lSDL_gfx -lGLEW -lGL -lpng -rdynamic -lpthread -lz";
@@ -44,7 +44,7 @@ void set_linux() {
 
 void set_mac() {
   preprocessor = "g++ -E";
-  compiler = "g++ -march=native -W -Wall -Wextra -pedantic -Wno-unused-parameter -Wno-implicit-fallthrough -c";
+  compiler = "g++ -march=native -W -Wall -Wextra -Wimplicit-fallthrough -pedantic -Wno-unused-parameter -c";
   linker = "g++ -o hyper";
   opts = "-DMAC -I/usr/local/include";
   libs = " savepng.o -L/usr/local/lib -framework AppKit -framework OpenGL -lSDL -lSDLMain -lSDL_gfx -lSDL_mixer -lSDL_ttf -lpng -lpthread -lz";
@@ -53,7 +53,7 @@ void set_mac() {
 void set_mingw64() {
   mingw64 = true;
   preprocessor = "g++ -E";
-  compiler = "g++ -mwindows -march=native -W -Wall -Wextra -Werror -Wno-unused-parameter -Wno-implicit-fallthrough -Wno-maybe-uninitialized -c";
+  compiler = "g++ -mwindows -march=native -W -Wall -Wextra -Werror -Wno-unused-parameter -Wno-maybe-uninitialized -c";
   linker = "g++ -o hyper";
   opts = "-DWINDOWS -DCAP_GLEW=1 -DCAP_PNG=1";
   libs = " savepng.o hyper.res -lopengl32 -lSDL -lSDL_gfx -lSDL_mixer -lSDL_ttf -lpthread -lz -lglew32 -lpng";

--- a/nonisotropic.cpp
+++ b/nonisotropic.cpp
@@ -427,10 +427,12 @@ EX namespace sn {
           case 8:
             return xpush(bw*(4.5-j)) * zpush(-1) * ypush(bw*(i-7));
           }
+        break;
         }
 
-      default: throw "not nihsolv";
+      default: break;
       }
+      throw "not nihsolv";
       }
 
     transmatrix adj(heptagon *h, int d) override {

--- a/pattern2.cpp
+++ b/pattern2.cpp
@@ -1747,6 +1747,7 @@ EX namespace patterns {
         if(arcm::in()) return colortables['A'][arcm::current.tilegroup[arcm::id_of(c->master)]];
         #endif
         if(arb::in()) return colortables['A'][c->master->zebraval + c->master->emeraldval * isize(arb::current.shapes)];
+        return colortables['B'][c->type & 15];
       case 'B':
         return colortables['B'][c->type & 15];
       #if CAP_FIELD


### PR DESCRIPTION
Clang doesn't enable this warning by default, so we pass it explicitly.
GCC pre-GCC 7 doesn't recognize the flag, so we can't pass it for GCC.
GCC 7 enables it by default as part of -Wextra.

Fixes #68.