### PR TITLE
Fix colors for big endian architectures

### DIFF
--- a/polygons.cpp
+++ b/polygons.cpp
@@ -762,7 +762,12 @@ void fixMercator(bool tinf) {
   }
   
 unsigned char& part(color_t& col, int i) {
-  unsigned char* c = (unsigned char*) &col; return c[i];
+  unsigned char* c = (unsigned char*) &col;
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+  return c[sizeof(col) - 1 - i];
+#else
+  return c[i];
+#endif
   }
 
 bool in_twopoint = false;

--- a/shaders.cpp
+++ b/shaders.cpp
@@ -339,9 +339,9 @@ void id_modelview() {
 #endif
 
 void color2(color_t color, ld part) {
-  unsigned char *c = (unsigned char*) (&color);
   GLfloat cols[4];
-  for(int i=0; i<4; i++) cols[i] = c[3-i] / 255.0 * part;
+  for(int i=0; i<4; i++)
+    cols[i] = (color >> ((3-i) * 8) & 0xff) / 255.0 * part;
   #if CAP_SHADER
   // glUniform4fv(current->uFog, 4, cols);
   glUniform4f(current->uColor, cols[0], cols[1], cols[2], cols[3]);
@@ -352,8 +352,12 @@ void color2(color_t color, ld part) {
 
 void colorClear(color_t color) {
   unsigned char *c = (unsigned char*) (&color);
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+  glClearColor(c[0] / 255.0, c[1] / 255.0, c[2]/255.0, c[3] / 255.0);
+#else
   glClearColor(c[3] / 255.0, c[2] / 255.0, c[1]/255.0, c[0] / 255.0);
-  }
+#endif
+}
 
 void be_nontextured(shader_projection sp) { switch_mode(gmColored, sp); }
 void be_textured(shader_projection sp) { switch_mode(gmTextured, sp); }


### PR DESCRIPTION
Hi, 

It has been noticed by @ibara that colors are off when playing HyperRogue on a big endian machine. Blue was red etc. (see https://marc.info/?l=openbsd-ports&m=154739730704091&w=2). 

Here is a PR that fixes the issues in GL and textured mode. 