### PR TITLE
Avoid casting to `unsigned char*` in color calculations.

### DIFF
--- a/basegraph.cpp
+++ b/basegraph.cpp
@@ -851,7 +851,7 @@ void addMessage(string s, char spamtype) {
 
 color_t colormix(color_t a, color_t b, color_t c) {
   for(int p=0; p<3; p++)
-    setpart(a, p, part(a,p) + (part(b,p) - part(a,p)) * part(c,p) / 255);
+    setpart(a, p) = part(a,p) + (part(b,p) - part(a,p)) * part(c,p) / 255;
   return a;
   }
 
@@ -946,7 +946,7 @@ color_t gradient(color_t c0, color_t c1, ld v0, ld v, ld v1) {
   for(int a=0; a<3; a++) {
     int p0 = part(c0, a);
     int p1 = part(c1, a);
-    setpart(c, a, (p0*(256-vv) + p1*vv + 127) >> 8);
+    setpart(c, a) = (p0*(256-vv) + p1*vv + 127) >> 8;
     }
   return c;
   }

--- a/basegraph.cpp
+++ b/basegraph.cpp
@@ -306,8 +306,7 @@ void setGLProjection(color_t col) {
   DEBB(DF_GRAPH, (debugfile,"setGLProjection\n"));
   GLERR("pre_setGLProjection");
 
-  unsigned char *c = (unsigned char*) (&col);
-  glClearColor(c[2] / 255.0, c[1] / 255.0, c[0]/255.0, 1);
+  glClearColor(part(col, 2) / 255.0, part(col, 1) / 255.0, part(col, 0) / 255.0, 1);
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
   GLERR("setGLProjection #1");
@@ -852,7 +851,7 @@ void addMessage(string s, char spamtype) {
 
 color_t colormix(color_t a, color_t b, color_t c) {
   for(int p=0; p<3; p++)
-    part(a, p) = part(a,p) + (part(b,p) - part(a,p)) * part(c,p) / 255;
+    setpart(a, p, part(a,p) + (part(b,p) - part(a,p)) * part(c,p) / 255);
   return a;
   }
 
@@ -947,7 +946,7 @@ color_t gradient(color_t c0, color_t c1, ld v0, ld v, ld v1) {
   for(int a=0; a<3; a++) {
     int p0 = part(c0, a);
     int p1 = part(c1, a);
-    part(c, a) = (p0*(256-vv) + p1*vv + 127) >> 8;
+    setpart(c, a, (p0*(256-vv) + p1*vv + 127) >> 8);
     }
   return c;
   }

--- a/dialogs.cpp
+++ b/dialogs.cpp
@@ -481,7 +481,7 @@ namespace dialog {
       int x = (mousex - (dcenter-dwidth/4)) * 510 / dwidth;
       if(x < 0) x = 0;
       if(x > 255) x = 255;
-      setpart(color, uni - 'A', x);
+      setpart(color, uni - 'A') = x;
       }
     else if(uni == ' ' || uni == '\n' || uni == '\r') {
       bool inHistory = false;
@@ -504,10 +504,10 @@ namespace dialog {
       colorp = (colorp+1) & 3;
       }
     else if(DKEY == SDLK_LEFT) {
-      setpart(color, colorp, part(color, colorp) - abs(shiftmul) < .6 ? 1 : 17);
+      setpart(color, colorp) = part(color, colorp) - abs(shiftmul) < .6 ? 1 : 17;
       }
     else if(DKEY == SDLK_RIGHT) {
-      setpart(color, colorp, part(color, colorp) + abs(shiftmul) < .6 ? 1 : 17);
+      setpart(color, colorp) = part(color, colorp) + abs(shiftmul) < .6 ? 1 : 17;
       }
     else if(doexiton(sym, uni)) {
       popScreen();

--- a/dialogs.cpp
+++ b/dialogs.cpp
@@ -481,7 +481,7 @@ namespace dialog {
       int x = (mousex - (dcenter-dwidth/4)) * 510 / dwidth;
       if(x < 0) x = 0;
       if(x > 255) x = 255;
-      part(color, uni - 'A') = x;
+      setpart(color, uni - 'A', x);
       }
     else if(uni == ' ' || uni == '\n' || uni == '\r') {
       bool inHistory = false;
@@ -504,12 +504,10 @@ namespace dialog {
       colorp = (colorp+1) & 3;
       }
     else if(DKEY == SDLK_LEFT) {
-      unsigned char* pts = (unsigned char*) &color;
-      pts[colorp] -= abs(shiftmul) < .6 ? 1 : 17;
+      setpart(color, colorp, part(color, colorp) - abs(shiftmul) < .6 ? 1 : 17);
       }
     else if(DKEY == SDLK_RIGHT) {
-      unsigned char* pts = (unsigned char*) &color;
-      pts[colorp] += abs(shiftmul) < .6 ? 1 : 17;
+      setpart(color, colorp, part(color, colorp) + abs(shiftmul) < .6 ? 1 : 17);
       }
     else if(doexiton(sym, uni)) {
       popScreen();

--- a/dialogs.cpp
+++ b/dialogs.cpp
@@ -504,10 +504,10 @@ namespace dialog {
       colorp = (colorp+1) & 3;
       }
     else if(DKEY == SDLK_LEFT) {
-      setpart(color, colorp) = part(color, colorp) - abs(shiftmul) < .6 ? 1 : 17;
+      setpart(color, colorp) -= abs(shiftmul) < .6 ? 1 : 17;
       }
     else if(DKEY == SDLK_RIGHT) {
-      setpart(color, colorp) = part(color, colorp) + abs(shiftmul) < .6 ? 1 : 17;
+      setpart(color, colorp) += abs(shiftmul) < .6 ? 1 : 17;
       }
     else if(doexiton(sym, uni)) {
       popScreen();

--- a/expansion.cpp
+++ b/expansion.cpp
@@ -510,7 +510,7 @@ bool scrolling_distances = false;
 color_t distribute_color(int id) {
   color_t v = 0xFFFFFF;
   for(int z=0; z<24; z++) if(id & (1<<z))
-    setpart(v, z%3, part(v, z%3) & ~(1<<(7-(z/3))));
+    setpart(v, z%3) = part(v, z%3) & ~(1<<(7-(z/3)));
   return v; 
   }
 

--- a/expansion.cpp
+++ b/expansion.cpp
@@ -509,7 +509,8 @@ bool scrolling_distances = false;
 
 color_t distribute_color(int id) {
   color_t v = 0xFFFFFF;
-  for(int z=0; z<24; z++) if(id & (1<<z)) part(v, (z%3)) &=~ (1<<(7-(z/3)));
+  for(int z=0; z<24; z++) if(id & (1<<z))
+    setpart(v, z%3, part(v, z%3) & ~(1<<(7-(z/3))));
   return v; 
   }
 

--- a/expansion.cpp
+++ b/expansion.cpp
@@ -510,7 +510,7 @@ bool scrolling_distances = false;
 color_t distribute_color(int id) {
   color_t v = 0xFFFFFF;
   for(int z=0; z<24; z++) if(id & (1<<z))
-    setpart(v, z%3) = part(v, z%3) & ~(1<<(7-(z/3)));
+    setpart(v, z%3) &= ~(1<<(7-(z/3)));
   return v; 
   }
 

--- a/graph.cpp
+++ b/graph.cpp
@@ -2343,7 +2343,7 @@ void drawaura() {
         double c1 = aurac[rm][2-c] / (aurac[rm][3]+.1);
         double c2 = aurac[rm+1][2-c] / (aurac[rm+1][3]+.1);
         const ld one = 1;
-        part(p, c) = int(255 * min(one, bak[2-c] + cmul * ((c1 + fr * (c2-c1) - bak[2-c])))); 
+        setpart(p, c, int(255 * min(one, bak[2-c] + cmul * ((c1 + fr * (c2-c1) - bak[2-c])))));
         }
       }
     SDL_UnlockSurface(s);

--- a/graph.cpp
+++ b/graph.cpp
@@ -2343,7 +2343,7 @@ void drawaura() {
         double c1 = aurac[rm][2-c] / (aurac[rm][3]+.1);
         double c2 = aurac[rm+1][2-c] / (aurac[rm+1][3]+.1);
         const ld one = 1;
-        setpart(p, c, int(255 * min(one, bak[2-c] + cmul * ((c1 + fr * (c2-c1) - bak[2-c])))));
+        setpart(p, c) = int(255 * min(one, bak[2-c] + cmul * ((c1 + fr * (c2-c1) - bak[2-c]))));
         }
       }
     SDL_UnlockSurface(s);

--- a/hyper.h
+++ b/hyper.h
@@ -3274,7 +3274,8 @@ extern ld tessf, crossf, hexf, hcrossf, hexhexdist, hexvdist, hepvdist, rhexf;
 
 extern ld scalefactor, orbsize, floorrad0, floorrad1, zhexf;
 
-unsigned char& part(color_t& col, int i);
+unsigned char part(color_t col, int i);
+void setpart(color_t& col, int i, unsigned char value);
 
 transmatrix applyPatterndir(cell *c, const patterns::patterninfo& si);
 
@@ -3700,7 +3701,7 @@ namespace glhr {
   
   void set_depthtest(bool b);
   glmatrix translate(ld x, ld y, ld z);
-  void color2(color_t color, ld part = 1);
+  void color2(color_t color, ld scale = 1);
   void be_nontextured(shader_projection sp = new_shader_projection);
   void be_textured(shader_projection sp = new_shader_projection);
   void set_modelview(const glmatrix& m);  

--- a/hyper.h
+++ b/hyper.h
@@ -3274,8 +3274,23 @@ extern ld tessf, crossf, hexf, hcrossf, hexhexdist, hexvdist, hepvdist, rhexf;
 
 extern ld scalefactor, orbsize, floorrad0, floorrad1, zhexf;
 
-unsigned char part(color_t col, int i);
-void setpart(color_t& col, int i, unsigned char value);
+inline unsigned char part(color_t col, int i) {
+  return col >> (8 * i);
+  }
+
+struct colorpartproxy {
+    color_t& col_;
+    int i_;
+    explicit colorpartproxy(color_t& col, int i) : col_(col), i_(i) {}
+    void operator=(unsigned char value) {
+      color_t mask = color_t(0xFF) << (8 * i_);
+      col_ = (col_ & ~mask) | (color_t(value) << (8 * i_));
+      }
+};
+
+inline colorpartproxy setpart(color_t& col, int i) {
+  return colorpartproxy(col, i);
+  }
 
 transmatrix applyPatterndir(cell *c, const patterns::patterninfo& si);
 

--- a/hyper.h
+++ b/hyper.h
@@ -3286,6 +3286,18 @@ struct colorpartproxy {
       color_t mask = color_t(0xFF) << (8 * i_);
       col_ = (col_ & ~mask) | (color_t(value) << (8 * i_));
       }
+    void operator+=(unsigned char value) {
+      *this = part(col_, i_) + value;
+      }
+    void operator-=(unsigned char value) {
+      *this = part(col_, i_) - value;
+      }
+    void operator&=(unsigned char value) {
+      *this = part(col_, i_) & value;
+      }
+    void operator/=(int value) {
+      *this = part(col_, i_) / value;
+      }
 };
 
 inline colorpartproxy setpart(color_t& col, int i) {

--- a/pattern2.cpp
+++ b/pattern2.cpp
@@ -1916,7 +1916,7 @@ bool is_master(cell *c) {
 namespace linepatterns {
 
   color_t lessalpha(color_t col, int m) {
-    setpart(col, 0) = part(col, 0) / m;
+    setpart(col, 0) /= m;
     return col;
     }
   

--- a/pattern2.cpp
+++ b/pattern2.cpp
@@ -1916,7 +1916,7 @@ bool is_master(cell *c) {
 namespace linepatterns {
 
   color_t lessalpha(color_t col, int m) {
-    setpart(col, 0, part(col, 0) / m);
+    setpart(col, 0) = part(col, 0) / m;
     return col;
     }
   

--- a/pattern2.cpp
+++ b/pattern2.cpp
@@ -1916,7 +1916,7 @@ bool is_master(cell *c) {
 namespace linepatterns {
 
   color_t lessalpha(color_t col, int m) {
-    part(col, 0) /= m;
+    setpart(col, 0, part(col, 0) / m);
     return col;
     }
   

--- a/polygons.cpp
+++ b/polygons.cpp
@@ -383,8 +383,8 @@ void drawTexturedTriangle(SDL_Surface *s, int *px, int *py, glvertex *tv, color_
       auto& pix = qpixel(s, mx, my);
       for(int p=0; p<3; p++) {
         int alpha = part(c, 3) * part(col, 0);
-        auto& v = part(pix, p);
-        v = ((255*255 - alpha) * 255 * v + alpha * part(col, p+1) * part(c, p) + 255 * 255 * 255/2 + 1) / (255 * 255 * 255);
+        int v = part(pix, p);
+        setpart(pix, p, ((255*255 - alpha) * 255 * v + alpha * part(col, p+1) * part(c, p) + 255 * 255 * 255/2 + 1) / (255 * 255 * 255));
         }
       }
     }
@@ -761,8 +761,13 @@ void fixMercator(bool tinf) {
     
   }
   
-unsigned char& part(color_t& col, int i) {
-  unsigned char* c = (unsigned char*) &col; return c[i];
+unsigned char part(color_t col, int i) {
+  return col >> (8 * i);
+  }
+
+void setpart(color_t& col, int i, unsigned char value) {
+  color_t mask = color_t(0xFF) << (8 * i);
+  col = (col & ~mask) | (color_t(value) << (8 * i));
   }
 
 bool in_twopoint = false;
@@ -2674,10 +2679,12 @@ dqi_poly& queuepolyat(const transmatrix& V, const hpcshape& h, color_t col, PPR 
     /* int r = (625 * part(col,3) + 375 * part(col,2)) / 1000;
     int g = (700 * part(col,3) + 300 * part(col,2)) / 1000;
     int b = (300 * part(col,2) + 700 * part(col,1)) / 1000; 
-    part(col,3) = r;
-    part(col,2) = g;
-    part(col,1) = b; */
-    part(col,2) = part(col,3) = (part(col,2) * 2 + part(col,3) + 1)/3;
+    setpart(col,3, r);
+    setpart(col,2, g);
+    setpart(col,1, b); */
+    int gb = (part(col,2) * 2 + part(col,3) + 1)/3;
+    setpart(col, 2, gb);
+    setpart(col, 3, gb);
     }
   ptd.color = (darkened(col >> 8) << 8) + (col & 0xFF);
   ptd.outline = poly_outline;

--- a/polygons.cpp
+++ b/polygons.cpp
@@ -384,7 +384,7 @@ void drawTexturedTriangle(SDL_Surface *s, int *px, int *py, glvertex *tv, color_
       for(int p=0; p<3; p++) {
         int alpha = part(c, 3) * part(col, 0);
         int v = part(pix, p);
-        setpart(pix, p, ((255*255 - alpha) * 255 * v + alpha * part(col, p+1) * part(c, p) + 255 * 255 * 255/2 + 1) / (255 * 255 * 255));
+        setpart(pix, p) = ((255*255 - alpha) * 255 * v + alpha * part(col, p+1) * part(c, p) + 255 * 255 * 255/2 + 1) / (255 * 255 * 255);
         }
       }
     }
@@ -761,15 +761,6 @@ void fixMercator(bool tinf) {
     
   }
   
-unsigned char part(color_t col, int i) {
-  return col >> (8 * i);
-  }
-
-void setpart(color_t& col, int i, unsigned char value) {
-  color_t mask = color_t(0xFF) << (8 * i);
-  col = (col & ~mask) | (color_t(value) << (8 * i));
-  }
-
 bool in_twopoint = false;
 
 ld glhypot2(glvertex a, glvertex b) { 
@@ -2679,12 +2670,12 @@ dqi_poly& queuepolyat(const transmatrix& V, const hpcshape& h, color_t col, PPR 
     /* int r = (625 * part(col,3) + 375 * part(col,2)) / 1000;
     int g = (700 * part(col,3) + 300 * part(col,2)) / 1000;
     int b = (300 * part(col,2) + 700 * part(col,1)) / 1000; 
-    setpart(col,3, r);
-    setpart(col,2, g);
-    setpart(col,1, b); */
+    setpart(col,3) = r;
+    setpart(col,2) = g;
+    setpart(col,1) = b; */
     int gb = (part(col,2) * 2 + part(col,3) + 1)/3;
-    setpart(col, 2, gb);
-    setpart(col, 3, gb);
+    setpart(col, 2) = gb;
+    setpart(col, 3) = gb;
     }
   ptd.color = (darkened(col >> 8) << 8) + (col & 0xFF);
   ptd.outline = poly_outline;

--- a/rogueviz-graph.cpp
+++ b/rogueviz-graph.cpp
@@ -88,7 +88,7 @@ void make_texture() {
       }
     ld hyp = hypot(bx-tw/16, by-tw/16) / (tw/16);
     if(hyp > 1) hyp = 1;
-    setpart(pix(0,x,y), p, 255 * (1 * hyp + (0.5 + h[p]/2) * (1-hyp)));
+    setpart(pix(0,x,y), p) = 255 * (1 * hyp + (0.5 + h[p]/2) * (1-hyp));
     }
   
   tdata.loadTextureGL();

--- a/rogueviz-graph.cpp
+++ b/rogueviz-graph.cpp
@@ -88,7 +88,7 @@ void make_texture() {
       }
     ld hyp = hypot(bx-tw/16, by-tw/16) / (tw/16);
     if(hyp > 1) hyp = 1;
-    part(pix(0,x,y), p) = 255 * (1 * hyp + (0.5 + h[p]/2) * (1-hyp));
+    setpart(pix(0,x,y), p, 255 * (1 * hyp + (0.5 + h[p]/2) * (1-hyp)));
     }
   
   tdata.loadTextureGL();

--- a/rogueviz-kohonen.cpp
+++ b/rogueviz-kohonen.cpp
@@ -185,7 +185,7 @@ void coloring() {
         }
 
       for(int i=0; i<cells; i++) {
-        part(net[i].where->landparam_color, pid) = part(vdata[net[i].bestsample].cp.color1, pid+1);
+        setpart(net[i].where->landparam_color, pid, part(vdata[net[i].bestsample].cp.color1, pid+1));
         }
       }
 
@@ -221,7 +221,7 @@ void coloring() {
       if(maxl-minl < 1e-3) maxl = minl+1e-3;
       
       for(int i=0; i<cells; i++) 
-        part(net[i].where->landparam_color, pid) = (255 * (listing[i] - minl)) / (maxl - minl);
+        setpart(net[i].where->landparam_color, pid, (255 * (listing[i] - minl)) / (maxl - minl));
       }
     }
   }

--- a/rogueviz-kohonen.cpp
+++ b/rogueviz-kohonen.cpp
@@ -185,7 +185,7 @@ void coloring() {
         }
 
       for(int i=0; i<cells; i++) {
-        setpart(net[i].where->landparam_color, pid, part(vdata[net[i].bestsample].cp.color1, pid+1));
+        setpart(net[i].where->landparam_color, pid) = part(vdata[net[i].bestsample].cp.color1, pid+1);
         }
       }
 
@@ -221,7 +221,7 @@ void coloring() {
       if(maxl-minl < 1e-3) maxl = minl+1e-3;
       
       for(int i=0; i<cells; i++) 
-        setpart(net[i].where->landparam_color, pid, (255 * (listing[i] - minl)) / (maxl - minl));
+        setpart(net[i].where->landparam_color, pid) = (255 * (listing[i] - minl)) / (maxl - minl);
       }
     }
   }

--- a/rogueviz-pentagonal.cpp
+++ b/rogueviz-pentagonal.cpp
@@ -82,7 +82,7 @@ void make_texture() {
       }
     ld hyp = hypot(bx-tw/16, by-tw/16) / (tw/16);
     if(hyp > 1) hyp = 1;
-    setpart(pix(0,x,y), p, 255 * (1 * hyp + (0.5 + h[p]/2) * (1-hyp)));
+    setpart(pix(0,x,y), p) = 255 * (1 * hyp + (0.5 + h[p]/2) * (1-hyp));
     }
   
   tdata.loadTextureGL();

--- a/rogueviz-pentagonal.cpp
+++ b/rogueviz-pentagonal.cpp
@@ -82,7 +82,7 @@ void make_texture() {
       }
     ld hyp = hypot(bx-tw/16, by-tw/16) / (tw/16);
     if(hyp > 1) hyp = 1;
-    part(pix(0,x,y), p) = 255 * (1 * hyp + (0.5 + h[p]/2) * (1-hyp));
+    setpart(pix(0,x,y), p, 255 * (1 * hyp + (0.5 + h[p]/2) * (1-hyp)));
     }
   
   tdata.loadTextureGL();

--- a/rogueviz.cpp
+++ b/rogueviz.cpp
@@ -1096,7 +1096,7 @@ hpcshape *vshapes[4] = { &shDisk, &shDisk, &shHeptaMarker, &shSnowball };
 
 color_t darken_a(color_t c) {
   for(int p=0; p<3; p++)
-  for(int i=0; i<darken; i++) part(c, i+1) = (part(c, i+1) + part(backcolor, i)) >> 1;
+  for(int i=0; i<darken; i++) setpart(c, i+1, (part(c, i+1) + part(backcolor, i)) >> 1);
   return c;
   }
 
@@ -1178,7 +1178,7 @@ bool drawVertex(const transmatrix &V, cell *c, shmup::monster *m) {
       ei->lastdraw = frameid;
       
       color_t col = ei->type->color;
-      auto& alpha = part(col, 0);
+      int alpha = part(col, 0);
       
       if(kind == kSAG) {
         if(ei->weight2 > maxweight) maxweight = ei->weight2;
@@ -1187,7 +1187,9 @@ bool drawVertex(const transmatrix &V, cell *c, shmup::monster *m) {
         }
       if(hilite || hiliteclick) alpha = (alpha + 256) / 2;
       
-      if(svg::in && alpha < 16) continue;
+      if(svg::in && alpha < 16) {
+        continue;
+        }
       
       if(ISWEB) {
         if(alpha >= 128) alpha |= 15;
@@ -1197,6 +1199,7 @@ bool drawVertex(const transmatrix &V, cell *c, shmup::monster *m) {
         }
       
       alpha >>= darken;
+      setpart(col, 0, alpha);
 
       transmatrix gm1 = 
         (multidraw || elliptic) ? V * memo_relative_matrix(vd1.m->base, c) :
@@ -1734,7 +1737,7 @@ int readArgs() {
     }
   else if(argis("-ggamma")) {
     // backward compatibility
-    shift(); part(default_edgetype.color, 0) = 255 * pow(.5, argf());
+    shift(); setpart(default_edgetype.color, 0, 255 * pow(.5, argf()));
     }
   else if(argis("-cshift")) {
     shift_arg_formula(collatz::cshift);
@@ -2038,7 +2041,7 @@ slide rvslides[] = {
       rogueviz::dftcolor = 0x282828FF;
 
       rogueviz::showlabels = true;
-      part(rogueviz::default_edgetype.color, 0) = 181;
+      setpart(rogueviz::default_edgetype.color, 0, 181);
       rogueviz::sag::edgepower = 1;
       rogueviz::sag::edgemul = 1;
       
@@ -2058,7 +2061,7 @@ slide rvslides[] = {
       rogueviz::dftcolor = 0x282828FF;
 
       rogueviz::showlabels = true;
-      part(rogueviz::default_edgetype.color, 0) = 128;
+      setpart(rogueviz::default_edgetype.color, 0, 128);
       rogueviz::sag::edgepower = .4;
       rogueviz::sag::edgemul = .02;
       
@@ -2079,7 +2082,7 @@ slide rvslides[] = {
       rogueviz::dftcolor = 0x282828FF;
 
       rogueviz::showlabels = true;
-      part(rogueviz::default_edgetype.color, 0) = 157;
+      setpart(rogueviz::default_edgetype.color, 0, 157);
       rogueviz::sag::edgepower = 1;
       rogueviz::sag::edgemul = 1;
       

--- a/rogueviz.cpp
+++ b/rogueviz.cpp
@@ -1096,7 +1096,7 @@ hpcshape *vshapes[4] = { &shDisk, &shDisk, &shHeptaMarker, &shSnowball };
 
 color_t darken_a(color_t c) {
   for(int p=0; p<3; p++)
-  for(int i=0; i<darken; i++) setpart(c, i+1, (part(c, i+1) + part(backcolor, i)) >> 1);
+  for(int i=0; i<darken; i++) setpart(c, i+1) = (part(c, i+1) + part(backcolor, i)) >> 1;
   return c;
   }
 
@@ -1199,7 +1199,7 @@ bool drawVertex(const transmatrix &V, cell *c, shmup::monster *m) {
         }
       
       alpha >>= darken;
-      setpart(col, 0, alpha);
+      setpart(col, 0) = alpha;
 
       transmatrix gm1 = 
         (multidraw || elliptic) ? V * memo_relative_matrix(vd1.m->base, c) :
@@ -1737,7 +1737,7 @@ int readArgs() {
     }
   else if(argis("-ggamma")) {
     // backward compatibility
-    shift(); setpart(default_edgetype.color, 0, 255 * pow(.5, argf()));
+    shift(); setpart(default_edgetype.color, 0) = 255 * pow(.5, argf());
     }
   else if(argis("-cshift")) {
     shift_arg_formula(collatz::cshift);
@@ -2041,7 +2041,7 @@ slide rvslides[] = {
       rogueviz::dftcolor = 0x282828FF;
 
       rogueviz::showlabels = true;
-      setpart(rogueviz::default_edgetype.color, 0, 181);
+      setpart(rogueviz::default_edgetype.color, 0) = 181;
       rogueviz::sag::edgepower = 1;
       rogueviz::sag::edgemul = 1;
       
@@ -2061,7 +2061,7 @@ slide rvslides[] = {
       rogueviz::dftcolor = 0x282828FF;
 
       rogueviz::showlabels = true;
-      setpart(rogueviz::default_edgetype.color, 0, 128);
+      setpart(rogueviz::default_edgetype.color, 0) = 128;
       rogueviz::sag::edgepower = .4;
       rogueviz::sag::edgemul = .02;
       
@@ -2082,7 +2082,7 @@ slide rvslides[] = {
       rogueviz::dftcolor = 0x282828FF;
 
       rogueviz::showlabels = true;
-      setpart(rogueviz::default_edgetype.color, 0, 157);
+      setpart(rogueviz::default_edgetype.color, 0) = 157;
       rogueviz::sag::edgepower = 1;
       rogueviz::sag::edgemul = 1;
       

--- a/screenshot.cpp
+++ b/screenshot.cpp
@@ -28,9 +28,8 @@ namespace svg {
   
   bool invisible(color_t col) { return (col & 0xFF) == 0; }
   
-  void fixgamma(unsigned int& color) {
-    unsigned char *c = (unsigned char*) (&color);
-    for(int i=1; i<4; i++) c[i] = 255 * pow(float(c[i] / 255.0), float(shot::gamma));
+  void fixgamma(color_t& color) {
+    for(int i=1; i<4; i++) setpart(color, i, 255 * pow(float(part(color, i) / 255.0), float(shot::gamma)));
     }
   
   int svgsize;
@@ -51,7 +50,7 @@ namespace svg {
       }
     }
   
-  char* stylestr(unsigned int fill, unsigned int stroke, ld width=1) {
+  char* stylestr(color_t fill, color_t stroke, ld width=1) {
     fixgamma(fill);
     fixgamma(stroke);
     static char buf[600];
@@ -287,14 +286,14 @@ void postprocess(string fname, SDL_Surface *sdark, SDL_Surface *sbright) {
     
     color_t& pix = qpixel(sout, x, y);
     pix = 0;
-    part(pix, 3) = 255 - (255 * transparent + (maxval/2)) / maxval;
+    setpart(pix, 3, 255 - (255 * transparent + (maxval/2)) / maxval);
     
     if(transparent < maxval) for(int p=0; p<3; p++) {
       ld v = (val[0][p] * 3. / maxval) / (1 - transparent * 1. / maxval);
       v = pow(v, gamma) * fade;
       v *= 255;
       if(v > 255) v = 255;
-      part(pix, p) = v;
+      setpart(pix, p, v);
       }
     }
   IMAGESAVE(sout, fname.c_str());

--- a/screenshot.cpp
+++ b/screenshot.cpp
@@ -29,7 +29,7 @@ namespace svg {
   bool invisible(color_t col) { return (col & 0xFF) == 0; }
   
   void fixgamma(color_t& color) {
-    for(int i=1; i<4; i++) setpart(color, i, 255 * pow(float(part(color, i) / 255.0), float(shot::gamma)));
+    for(int i=1; i<4; i++) setpart(color, i) = 255 * pow(float(part(color, i) / 255.0), float(shot::gamma));
     }
   
   int svgsize;
@@ -286,14 +286,14 @@ void postprocess(string fname, SDL_Surface *sdark, SDL_Surface *sbright) {
     
     color_t& pix = qpixel(sout, x, y);
     pix = 0;
-    setpart(pix, 3, 255 - (255 * transparent + (maxval/2)) / maxval);
+    setpart(pix, 3) = 255 - (255 * transparent + (maxval/2)) / maxval;
     
     if(transparent < maxval) for(int p=0; p<3; p++) {
       ld v = (val[0][p] * 3. / maxval) / (1 - transparent * 1. / maxval);
       v = pow(v, gamma) * fade;
       v *= 255;
       if(v > 255) v = 255;
-      setpart(pix, p, v);
+      setpart(pix, p) = v;
       }
     }
   IMAGESAVE(sout, fname.c_str());

--- a/shaders.cpp
+++ b/shaders.cpp
@@ -338,10 +338,9 @@ void id_modelview() {
 
 #endif
 
-void color2(color_t color, ld part) {
-  unsigned char *c = (unsigned char*) (&color);
+void color2(color_t color, ld scale) {
   GLfloat cols[4];
-  for(int i=0; i<4; i++) cols[i] = c[3-i] / 255.0 * part;
+  for(int i=0; i<4; i++) cols[i] = part(color, 3-i) / 255.0 * scale;
   #if CAP_SHADER
   // glUniform4fv(current->uFog, 4, cols);
   glUniform4f(current->uColor, cols[0], cols[1], cols[2], cols[3]);
@@ -351,8 +350,7 @@ void color2(color_t color, ld part) {
   }
 
 void colorClear(color_t color) {
-  unsigned char *c = (unsigned char*) (&color);
-  glClearColor(c[3] / 255.0, c[2] / 255.0, c[1]/255.0, c[0] / 255.0);
+  glClearColor(part(color, 3) / 255.0, part(color, 2) / 255.0, part(color, 1) / 255.0, part(color, 0) / 255.0);
   }
 
 void be_nontextured(shader_projection sp) { switch_mode(gmColored, sp); }

--- a/surface.cpp
+++ b/surface.cpp
@@ -385,7 +385,7 @@ void draw_kuen_map() {
         auto& px = qpixel(kuen_map, r, h);
         px |= 0xFF000000;
         for(int k=0; k<3; k++)
-          setpart(px, k, vv[k] > 0 ? 0xFF : 0);
+          setpart(px, k) = vv[k] > 0 ? 0xFF : 0;
         px = 0xFF000000 + (((int)(n*255/nmax)) * (kuen_branch(v,u) == 1 ? 0x10101 : 0x10001));
         }
       }

--- a/surface.cpp
+++ b/surface.cpp
@@ -385,7 +385,7 @@ void draw_kuen_map() {
         auto& px = qpixel(kuen_map, r, h);
         px |= 0xFF000000;
         for(int k=0; k<3; k++)
-          part(px, k) = (vv[k] > 0 ? 0xFF : 0);
+          setpart(px, k, vv[k] > 0 ? 0xFF : 0);
         px = 0xFF000000 + (((int)(n*255/nmax)) * (kuen_branch(v,u) == 1 ? 0x10101 : 0x10001));
         }
       }

--- a/textures.cpp
+++ b/textures.cpp
@@ -59,7 +59,7 @@ template<class T, class U> void scale_colorarray(int origdim, int targetdim, con
     if(tmissing == 0) {
       color_t target = 0;
       for(int p=0; p<4; p++) {
-        setpart(target, p, partials[p] / origdim);
+        setpart(target, p) = partials[p] / origdim;
         partials[p] = 0;
         }
       dest(tx++, target);
@@ -71,8 +71,8 @@ template<class T, class U> void scale_colorarray(int origdim, int targetdim, con
 color_t swap_red_and_blue(color_t col) {
   unsigned char r = part(col, 0);
   unsigned char b = part(col, 2);
-  setpart(col, 0, b);
-  setpart(col, 2, r);
+  setpart(col, 0) = b;
+  setpart(col, 2) = r;
   return col;
   }
 
@@ -327,7 +327,7 @@ void texture_config::mapTexture2(textureinfo& mi) {
 int texture_config::recolor(color_t col) {
   if(color_alpha == 0) return col;
   for(int i=1; i<4; i++)
-    setpart(col, i, color_alpha + ((255-color_alpha) * part(col,i) + 127) / 255);
+    setpart(col, i) = color_alpha + ((255-color_alpha) * part(col,i) + 127) / 255;
   return col;
   }
 


### PR DESCRIPTION
Fixes the same thing as #70, but in a different way.