### PR TITLE
Rearrange some macros. No functional change intended.

### DIFF
--- a/commandline.cpp
+++ b/commandline.cpp
@@ -39,7 +39,7 @@ eMonster readMonster(const string& ss) {
 void initializeCLI() {
   printf("HyperRogue by Zeno Rogue <zeno@attnam.com>, version " VER "\n");
 
-#ifndef NOLICENSE
+#if !NOLICENSE
   printf("released under GNU General Public License version 2 and thus\n");
   printf("comes with absolutely no warranty; see COPYING for details\n");
 #endif

--- a/help.cpp
+++ b/help.cpp
@@ -137,7 +137,7 @@ void buildCredits() {
   help += XLAT("game design, programming, texts and graphics by Zeno Rogue <zeno@attnam.com>\n\n");
   if(lang() != 0)
     help += XLAT("add credits for your translation here");
-#ifndef NOLICENSE
+#if !NOLICENSE
   help += XLAT(
     "released under GNU General Public License version 2 and thus "
     "comes with absolutely no warranty; see COPYING for details\n\n"

--- a/hyper.h
+++ b/hyper.h
@@ -7,9 +7,7 @@
 #define VERNUM_HEX 0xA505
 
 #include <stdarg.h>
-#if !ISSTEAM
 #include "hyper_function.h"
-#endif
 
 namespace hr {
 
@@ -17,12 +15,6 @@ template<class T>
 void ignore(T&&) {
   // placate GCC's overzealous -Wunused-result
   }
-
-#if USE_STDFUNCTION
-using std::function;
-#else
-template<class Sig> using function = hyper_function<Sig>;
-#endif
 
 // functions and types used from the standard library
 using std::vector;

--- a/hyper_function.h
+++ b/hyper_function.h
@@ -1,10 +1,24 @@
 #pragma once
 
+#if USE_STDFUNCTION
+
+#include <functional>
+namespace hr {
+    using std::function;
+} // namespace hr
+
+#else
+
 #include <type_traits>
 #include <utility>
 
+namespace hr {
+
 template<class Sig>
 class hyper_function;
+
+template<class Sig>
+using function = hyper_function<Sig>;
 
 template<class R, class... Args>
 struct hyper_function_state_base {
@@ -59,3 +73,7 @@ public:
         return ptr_ != nullptr;
     }
 };
+
+} // namespace hr
+
+#endif

--- a/quit.cpp
+++ b/quit.cpp
@@ -160,9 +160,7 @@ hint hints[] = {
         "Try the Orb Strategy mode!")
         );
       dialog::addBreak(50);
-#ifdef INF
       dialog::addItem(XLAT("Orb Strategy mode"), 'z');
-#endif
       },
     []() {
 #if CAP_INV

--- a/sysconfig.h
+++ b/sysconfig.h
@@ -13,18 +13,6 @@
 #define ISWINDOWS 1
 #endif
 
-#if ISSTEAM
-#define NOLICENSE
-#endif
-
-#ifndef USE_STDFUNCTION
-#define USE_STDFUNCTION ISSTEAM
-#endif
-
-#ifndef CAP_SHADER
-#define CAP_SHADER CAP_GL
-#endif
-
 // OS settings
 
 #ifndef ISMAC
@@ -51,6 +39,10 @@
 #define ISANDROID 0
 #endif
 
+#ifndef ISSTEAM
+#define ISSTEAM 0
+#endif
+
 #ifndef ISWEB
 #define ISWEB 0
 #endif
@@ -72,16 +64,28 @@
 
 #define CAP_FRAMELIMIT (!ISMOBWEB)
 
-#if ISMOBILE==1
+#if ISMOBILE
 #define EXTERNALFONT
 #endif
 
-#ifndef CAP_FILES
-#define CAP_FILES 1
+#ifndef NOLICENSE
+#define NOLICENSE ISSTEAM
+#endif
+
+#ifndef USE_STDFUNCTION
+#define USE_STDFUNCTION ISSTEAM
+#endif
+
+#ifndef CAP_SHADER
+#define CAP_SHADER CAP_GL
 #endif
 
 #ifndef CAP_ANIMATIONS
 #define CAP_ANIMATIONS (!CAP_MINI)
+#endif
+
+#ifndef CAP_FILES
+#define CAP_FILES 1
 #endif
 
 #ifndef CAP_INV
@@ -237,16 +241,12 @@
 #define CAP_SHMUP 1
 #endif
 
-#ifdef ISSTEAM
-#define CAP_ACHIEVE 1
-#endif
-
 #ifndef CAP_BITFIELD
 #define CAP_BITFIELD (!ISWEB)
 #endif
 
 #ifndef CAP_ACHIEVE
-#define CAP_ACHIEVE 0
+#define CAP_ACHIEVE ISSTEAM
 #endif
 
 #ifndef CAP_SHMUP_GOOD


### PR DESCRIPTION
Consistently use `#if`, not `#ifdef`, for `ISSTEAM`. Move its initialization into the same place as `ISMAC`, `ISFAKEMOBILE`, etc.

Rearrange the `USE_STDFUNCTION` macros for straightforwardness.

Eliminate an obsolete check for `#ifdef INF` which is always true at this point.