### PR TITLE
Add language-data.cpp as dependency for autohdr.h

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,7 +25,7 @@ BUILT_SOURCES = language-data.cpp autohdr.h
 language-data.cpp: langen
 	./langen > language-data.cpp
 
-autohdr.h: makeh *.cpp
+autohdr.h: makeh language-data.cpp *.cpp
 	./makeh locations.cpp hyperpoint.cpp geometry.cpp goldberg.cpp init.cpp floorshapes.cpp cell.cpp multi.cpp shmup.cpp pattern2.cpp mapeditor.cpp graph.cpp textures.cpp hprint.cpp language.cpp *.cpp > autohdr.h
 
 #############################


### PR DESCRIPTION
When building in parallel, it could happen that autohdr.h is generated
before language-data.cpp was available and the compilation fails.