### PR TITLE
Fix several minor issues causing TravisCI to be red

### DIFF
--- a/Makefile.simple
+++ b/Makefile.simple
@@ -63,7 +63,7 @@ ifeq (${OS},mingw)
   LDFLAGS_GL := -lopengl32
   LDFLAGS_GLEW := -lglew32
   LDFLAGS_PNG := -lpng
-  LDFLAGS_SDL := -lSDL -lSDL_gfx -lSDL_mixer -lSDL_ttf -lz -lphtread
+  LDFLAGS_SDL := -lSDL -lSDL_gfx -lSDL_mixer -lSDL_ttf -lpthread -lz
   OBJ_EXTENSION := .o
   hyper_RES := hyper.res
   ifeq (${HYPERROGUE_USE_GLEW},)
@@ -78,7 +78,7 @@ ifeq (${OS},osx)
   LDFLAGS_GL := -framework AppKit -framework OpenGL
   LDFLAGS_GLEW := -lGLEW
   LDFLAGS_PNG := -lpng
-  LDFLAGS_SDL := -lSDL -lSDLMain -lSDL_gfx -lSDL_mixer -lSDL_ttf -lz -lpthread
+  LDFLAGS_SDL := -lSDL -lSDLMain -lSDL_gfx -lSDL_mixer -lSDL_ttf -lpthread -lz
   OBJ_EXTENSION := .o
   hyper_RES :=
 endif

--- a/reg3.cpp
+++ b/reg3.cpp
@@ -1126,7 +1126,7 @@ EX namespace reg3 {
         vector<int> possible;
         int pfv = parent->fieldval;
         if(geometry == gSpace535) pfv = 0;
-        for(auto s: nonlooping_earlier_states[{pfv, id}]) possible.push_back(s.second);
+        for(auto s: nonlooping_earlier_states[address{pfv, id}]) possible.push_back(s.second);
         id1 = hrand_elt(possible, 0);
         res->fiftyval = id1;
         find_emeraldval(res, parent, d);

--- a/rogueviz/rewriting.cpp
+++ b/rogueviz/rewriting.cpp
@@ -117,7 +117,7 @@ void load_rules(vector<string> vs) {
 
   stop_game();
   set_geometry(gInfOrderMixed);
-  ginf[gInfOrderMixed].distlimit = {1, 1};
+  ginf[gInfOrderMixed].distlimit = {{1, 1}};
   ginf[gInfOrderMixed].flags |= qEXPERIMENTAL;
 
   start = "";


### PR DESCRIPTION
However, even with these fixed, TravisCI is _still_ red for the GCC 4.6 `-std=c++0x` build and for the Emscripten build.

I would like to get those banners back to green. Please let me know if you'd like to see patches in that direction. E.g.:

- Is `gcc-4.6` too old at this point? Shall we just retire it and move up to GCC 4.9.4-or-later?

- Shall we move up to C++14 at the same time? (I'm surprised that no C++14isms have crept in, even with the build red since e925f6e93ca358896bd4c2d7a73979d5fadb6d45.)

- Shall I invest any effort in sorting out why GCC 4.6 doesn't like `discoveries[k]`, and why each `discovery` needs a mutex in the first place, and whether the code still works if you unset `CAP_THREAD`? (HyperRogue does still compile on OSX if you set `-DCAP_THREAD=0`, for whatever that's worth.)

- Shall I invest any effort in figuring out how to use zlib on Emscripten? (So far, I don't even understand why it's needed.)