### PR TITLE
Remove all GCC 4.6 support, and for other purposes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,14 @@ matrix:
         sources:
           - ubuntu-toolchain-r-test
         packages:
-          - gcc-4.6
-          - g++-4.6
+          - gcc-5
+          - g++-5
     env: >-
       TRAVIS_OS_NAME=linux
       TRAVIS_BUILD_SYSTEM=Makefile
-      HYPERROGUE_CXX=g++-4.6
+      HYPERROGUE_CXX=g++-5
       HYPERROGUE_USE_GLEW=1
       HYPERROGUE_USE_PNG=1
-      EXTRA_CXXFLAGS=-DGCC46
   - os: linux
     compiler: gcc
     env: >-

--- a/Makefile.simple
+++ b/Makefile.simple
@@ -33,11 +33,7 @@ else
   ifneq (,$(findstring clang,$(TOOLCHAIN_VERSION_S)))
     TOOLCHAIN := clang
   else
-    ifneq (,$(findstring 4.6.,$(TOOLCHAIN_VERSION_S)))
-      TOOLCHAIN := gcc46
-    else
-      TOOLCHAIN := gcc
-    endif
+    TOOLCHAIN := gcc
   endif
 endif
 
@@ -93,12 +89,6 @@ ifeq (${TOOLCHAIN},gcc)
   CXXFLAGS_EARLY += -std=c++11 -march=native
   CXXFLAGS_EARLY += -W -Wall -Wextra -Werror
   CXXFLAGS_EARLY += -Wno-unknown-warning-option -Wno-maybe-uninitialized -Wno-missing-field-initializers -Wno-unused-parameter -Wno-implicit-fallthrough -Wno-maybe-uninitialized
-endif
-
-ifeq (${TOOLCHAIN},gcc46)
-  CXXFLAGS_EARLY += -std=c++0x
-  CXXFLAGS_EARLY += -W -Wall -Wextra -Werror
-  CXXFLAGS_EARLY += -Wno-unknown-warning-option -Wno-missing-field-initializers -Wno-unused-parameter -Wno-implicit-fallthrough -Wno-maybe-uninitialized
 endif
 
 ifeq (${TOOLCHAIN},mingw)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 A puzzle roguelike in the hyperbolic plane. See the [HyperRogue website](http://roguetemple.com/z/hyper.php) for detailed and most up-to-date information.
 Compiled executables can be downloaded from [itch.io](https://zenorogue.itch.io/hyperrogue) and from the [HyperRogue website](http://www.roguetemple.com/z/hyper/download.php).
 
-Released under [GNU General Public License, version 2](http://www.gnu.org/licenses/gpl-2.0.html). As such, it comes with without any warranty.
+Released under [GNU General Public License, version 2](http://www.gnu.org/licenses/gpl-2.0.html). As such, it comes without any warranty.
 
 If you would like to thank me for HyperRogue, you can support the development by buying paid versions (with more up-to-date content and some social and competitive features), or [in other ways](http://www.roguetemple.com/z/donate.php?id=hyper). 
 You can contact me at zeno@attnam.com, or at [my blog](http://zenorogue.blogspot.com/), or via [Twitter](https://twitter.com/ZenoRogue).
@@ -37,9 +37,9 @@ You can see tooltips by placing the mouse over stuff. You can also right click t
 
 Press v to configure the game. You can also rotate the world by pressing arrow keys, PageUp and PageDn (not numpad). You can center on the PC by pressing Home.
 
-Your scores and other stats about your games are recorded to file hyperrogue.log (in Linux, *~/.hyperrogue.log*). You can save your configation to file hyperrogue.ini (in Linux, *~/.hyperrogue.ini*).
+Your scores and other stats about your games are recorded to file hyperrogue.log (in Linux, *~/.hyperrogue.log*). You can save your configuration to file hyperrogue.ini (in Linux, *~/.hyperrogue.ini*).
 
-The surface the game is played on is called a hyperbolic plane. It seems there is just a very small amount of games and other works of art which use hyperbolic geometry (the most well known are some works of M.C.Escher).
+The surface the game is played on is called a hyperbolic plane. It seems there is just a very small amount of games and other works of art which use hyperbolic geometry (the most well known are some works of M.C.  Escher).
 
 The game dynamically generates new parts of the world as you move. Due to nature of the hyperbolic plane, the chances that you get back to a place where you have been before are very low (unless you go back exactly the same way). See more information about the geometry used [on the blog](http://zenorogue.blogspot.com/2012/03/hyperbolic-geometry-in-hyperbolic-rogue.html).
 

--- a/hyperpoint.cpp
+++ b/hyperpoint.cpp
@@ -47,20 +47,10 @@ eVariation variation;
 struct hyperpoint : array<ld, MAXMDIM> {
   hyperpoint() {}
   
-  #if ISGCC46
-  #if MAXMDIM == 4
-  // aaa
-  constexpr hyperpoint(ld x, ld y, ld z, ld w) : array<ld, MAXMDIM> { (array<ld, MAXMDIM>) {{x, y, z, w}}} {}
-  #else
-  constexpr hyperpoint(ld x, ld y, ld z, ld w) : array<ld, MAXMDIM> { (array<ld, MAXMDIM>) {{x, y, z}}} {}
-  #endif
-
-  #else
   #if MAXMDIM == 4
   constexpr hyperpoint(ld x, ld y, ld z, ld w) : array<ld, MAXMDIM> {{x,y,z,w}} {}
   #else
   constexpr hyperpoint(ld x, ld y, ld z, ld w) : array<ld, MAXMDIM> {{x,y,z}} {}
-  #endif
   #endif
 
   inline hyperpoint& operator *= (ld d) {

--- a/langen.cpp
+++ b/langen.cpp
@@ -65,7 +65,7 @@ int utfsize(char c) {
   return 4;
   }
 
-void addutftoset(std::set<std::string>& s, std::string& w) {
+void addutftoset(std::set<std::string>& s, const std::string& w) {
   size_t i = 0;
   while(i < w.size()) {
     int siz = utfsize(w[i]);
@@ -74,7 +74,7 @@ void addutftoset(std::set<std::string>& s, std::string& w) {
     }
   }
 
-void addutftoset(std::set<std::string>& s, noun& w) {
+void addutftoset(std::set<std::string>& s, const noun& w) {
   addutftoset(s, w.nom);
   addutftoset(s, w.nomp);
   addutftoset(s, w.acc);
@@ -82,7 +82,7 @@ void addutftoset(std::set<std::string>& s, noun& w) {
   }
 
 template<class T>
-void addutftoset(std::set<std::string>& s, dictionary<T>& w) {
+void addutftoset(std::set<std::string>& s, const dictionary<T>& w) {
   for(auto&& elt : w.m)
     addutftoset(s, elt.second);
   }
@@ -102,7 +102,7 @@ hashcode langhash(const std::string& s) {
     return langhash(s.substr(0, s.size() - 9)) + 1;
     }
   hashcode r = 0;
-  for(int i=0; i<isize(s); i++) r = hashval * r + s[i];
+  for (char ch : s) r = hashval * r + ch;
   return r;
   }
 

--- a/savemem.cpp
+++ b/savemem.cpp
@@ -216,7 +216,7 @@ EX void apply_memory_reserve() {
       }
     }
   catch(std::bad_alloc&) {}
-  #if (ISGCC46 || ISWINDOWS)
+  #if ISWINDOWS
   // no get_new_handler on this compiler...
   default_handler = [] { throw std::bad_alloc(); };
   #else

--- a/sysconfig.h
+++ b/sysconfig.h
@@ -48,13 +48,6 @@
 #define ISSTEAM 0
 #endif
 
-#if GCC46
-#define override
-#define ISGCC46 1
-#else
-#define ISGCC46 0
-#endif
-
 #ifndef ISWEB
 #define ISWEB 0
 #endif


### PR DESCRIPTION
- Remove all GCC 4.6 support; new minimum is GCC 5.4.
- Const-correctness in langen.cpp
- Fix some typos in the README

The first of these commits makes TravisCI completely green again!