### PR TITLE
Define `GL_SILENCE_DEPRECATION` on OSX

### DIFF
--- a/sysconfig.h
+++ b/sysconfig.h
@@ -389,6 +389,7 @@ extern "C" {
 #else
   #define GL_GLEXT_PROTOTYPES 1
   #if ISMAC
+    #define GL_SILENCE_DEPRECATION 1
     #include <OpenGL/gl.h>
     #include <OpenGL/glu.h>
     #include <OpenGL/glext.h>


### PR DESCRIPTION
This is gross and inexplicable, but Xcode now spews warnings whenever
you use any part of OpenGL on Mac.
https://www.reddit.com/r/opengl/comments/b44tyu/apple_is_deprecating_opengl/
https://www.reddit.com/r/opengl/comments/8okcf1/opengl_deprecated_in_macos_1014/
Fortunately the workaround for now is to just suppress the warnings.

    In file included from hyper.cpp:26:
    ./glhr.cpp:21:20: error: 'glGetError' is deprecated: first deprecated
          in macOS 10.14 - OpenGL API deprecated. (Define GL_SILENCE_DEPRECATION
          to silence these warnings) [-Werror,-Wdeprecated-declarations]
      GLenum errCode = glGetError();
                       ^