### PR TITLE
Fix setting doublebuffering

### DIFF
--- a/basegraph.cpp
+++ b/basegraph.cpp
@@ -1057,7 +1057,8 @@ EX void setvideomode() {
   
 #if CAP_GL
   if(vid.usingGL) {
-    flags = SDL_OPENGL | SDL_HWSURFACE | SDL_GL_DOUBLEBUFFER;
+    flags = SDL_OPENGL | SDL_HWSURFACE;
+    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
     SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 1);
     if(vsync_off) disable_vsync();
     if(vid.antialias & AA_MULTI) {


### PR DESCRIPTION
Setting OpenGL double buffering is currently broken. `SDL_GL_DOUBLEBUFFER` is passed to `SDL_Init()`, but is not an accepted flag for it. Instead it is correct to set the flag via a call to `SDL_GL_SetAttribute()`.