### PR TITLE
Get the build green again. Fix a bug in the Travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,6 @@ services:
 matrix:
   include:
   - os: linux
-    addons:
-      apt:
-        sources:
-          - ubuntu-toolchain-r-test
-        packages:
-          - gcc-5
-          - g++-5
-    env: >-
-      TRAVIS_OS_NAME=linux
-      TRAVIS_BUILD_SYSTEM=Makefile
-      HYPERROGUE_CXX=g++-5
-      HYPERROGUE_USE_GLEW=1
-      HYPERROGUE_USE_PNG=1
-  - os: linux
     compiler: gcc
     env: >-
       TRAVIS_OS_NAME=linux
@@ -41,6 +27,23 @@ matrix:
       TRAVIS_BUILD_SYSTEM=Makefile
       HYPERROGUE_USE_GLEW=1
       HYPERROGUE_USE_PNG=1
+  - os: linux
+    compiler: clang
+    env: >-
+      TRAVIS_OS_NAME=linux
+      TRAVIS_COMPILER_NAME=clang
+      TRAVIS_BUILD_SYSTEM=Makefile
+      HYPERROGUE_USE_GLEW=1
+      HYPERROGUE_USE_PNG=1
+  - os: linux
+    dist: bionic
+    compiler: gcc
+    env: >-
+      TRAVIS_OS_NAME=linux
+      TRAVIS_COMPILER_NAME=gcc
+      TRAVIS_BUILD_SYSTEM=Makefile
+      HYPERROGUE_USE_GLEW=1
+      HYPERROGUE_USE_PNG=1
       HYPERROGUE_USE_ROGUEVIZ=1
   - os: linux
     compiler: clang
@@ -51,6 +54,14 @@ matrix:
       HYPERROGUE_USE_GLEW=1
       HYPERROGUE_USE_PNG=1
       HYPERROGUE_USE_ROGUEVIZ=1
+  - os: osx
+    compiler: clang
+    env: >-
+      TRAVIS_OS_NAME=osx
+      TRAVIS_COMPILER_NAME=clang
+      TRAVIS_BUILD_SYSTEM=Makefile
+      HYPERROGUE_USE_GLEW=1
+      HYPERROGUE_USE_PNG=1
   - os: osx
     compiler: gcc
     env: >-
@@ -69,15 +80,6 @@ matrix:
       HYPERROGUE_USE_GLEW=1
       HYPERROGUE_USE_PNG=1
       HYPERROGUE_USE_ROGUEVIZ=1
-  - os: osx
-    compiler: clang
-    env: >-
-      TRAVIS_OS_NAME=osx
-      TRAVIS_COMPILER_NAME=clang
-      TRAVIS_BUILD_SYSTEM=Makefile
-      HYPERROGUE_USE_GLEW=0
-      HYPERROGUE_USE_PNG=0
-      HYPERROGUE_USE_ROGUEVIZ=0
   - os: linux
     env: >-
       TRAVIS_OS_NAME=linux
@@ -140,7 +142,7 @@ script:
     ./configure CXXFLAGS="-W -Wall -Wextra -Werror -Wno-unused-parameter -Wno-maybe-uninitialized -Wno-unknown-warning-option"
     make
   elif [[ "$TRAVIS_BUILD_SYSTEM" == "Makefile" ]]; then
-    make -f Makefile.simple CXX="${HYPERROGUE_CXX-g++}"
+    make -f Makefile.simple
   elif [[ "$TRAVIS_BUILD_SYSTEM" == "emscripten" ]]; then
     docker run --rm -v $(pwd):/src trzeci/emscripten make -f Makefile.simple emscripten
   else

--- a/Makefile.simple
+++ b/Makefile.simple
@@ -80,19 +80,22 @@ ifeq (${OS},osx)
 endif
 
 ifeq (${TOOLCHAIN},clang)
-  CXXFLAGS_EARLY += -std=c++11 -march=native
+  CXXFLAGS_STD = -std=c++11
+  CXXFLAGS_EARLY += -march=native
   CXXFLAGS_EARLY += -W -Wall -Wextra -Werror -pedantic
   CXXFLAGS_EARLY += -Wno-unused-parameter -Wno-implicit-fallthrough -Wno-maybe-uninitialized -Wno-unknown-warning-option
 endif
 
 ifeq (${TOOLCHAIN},gcc)
-  CXXFLAGS_EARLY += -std=c++11 -march=native
+  CXXFLAGS_STD = -std=c++11
+  CXXFLAGS_EARLY += -march=native
   CXXFLAGS_EARLY += -W -Wall -Wextra -Werror -pedantic
   CXXFLAGS_EARLY += -Wno-unused-parameter -Wno-implicit-fallthrough -Wno-maybe-uninitialized
 endif
 
 ifeq (${TOOLCHAIN},mingw)
-  CXXFLAGS_EARLY += -std=c++11 -march=native
+  CXXFLAGS_STD = -std=c++11
+  CXXFLAGS_EARLY += -march=native
   CXXFLAGS_EARLY += -W -Wall -Wextra -Werror
   CXXFLAGS_EARLY += -Wno-unused-parameter -Wno-implicit-fallthrough -Wno-maybe-uninitialized
 endif
@@ -121,7 +124,8 @@ else
 endif
 
 ifeq (${HYPERROGUE_USE_ROGUEVIZ},1)
-  # Enable RogueViz.
+  # Enable RogueViz. RogueViz requires C++17.
+  CXXFLAGS_STD = -std=c++17
   CXXFLAGS_EARLY += -DCAP_ROGUEVIZ=1
 endif
 
@@ -130,7 +134,7 @@ endif
 ## Begin the Makefile proper.
 
 
-override CXXFLAGS := $(CXXFLAGS_EARLY) $(CXXFLAGS) ${EXTRA_CXXFLAGS}
+override CXXFLAGS := $(CXXFLAGS_STD) $(CXXFLAGS_EARLY) $(CXXFLAGS) ${EXTRA_CXXFLAGS}
 override LDFLAGS := $(LDFLAGS_EARLY) $(LDFLAGS) ${EXTRA_LDFLAGS}
 
 hyperrogue$(EXE_EXTENSION): $(hyper_OBJS) $(hyper_RES)


### PR DESCRIPTION
The `HYPERROGUE_USE_ROGUEVIZ=1` build now uses inline variables.
So we pass `-std=c++17` in the Makefile. But GCC 5.4.0 (Travis's
default system compiler on Ubuntu Xenial) doesn't recognize
inline variables even in `-std=c++17` mode. Therefore, we must
pass `dist: bionic` to Travis, to get it to use Ubuntu Bionic,
whose system compiler is GCC 7.4.0. But we do this only for the
one entry in the build matrix that builds RogueViz with GCC
on Linux. Nobody else needs `dist: bionic`.

The bug was that my hack to support `g++-5` accidentally prevented
Travis from ever using `clang++`! So all our "Clang" builds were quietly
using regular `g++` instead. This is now fixed, and in fact I've removed
the `g++-5` build because its GCC 5.5.0 is not significantly different
from the regular `g++` build's GCC 5.4.0.

Also, add two more configurations to the build matrix.
Since `HYPERROGUE_USE_ROGUEVIZ=1` now uses `-std=c++17`, we want to
make sure that we run builds on every platform both with `HYPERROGUE_USE_ROGUEVIZ=1`
(to prove that the RogueViz code compiles) and without (to prove that
the non-RogueViz code still compiles as `-std=c++11`).