### PR TITLE
Move all defaulting-of-`CAP_FOO` to sysconfig.h

### DIFF
--- a/achievement.cpp
+++ b/achievement.cpp
@@ -952,12 +952,12 @@ EX void achievement_display() {
     col /= 10; col *= 0x10101;
     displayfr(vid.xres/2, vid.yres/4, 2, vid.fsize * 2, achievementMessage[0], col & 0xFFFF00, 8);
     int w = 2 * vid.fsize;
-#if ISMOBILE==0
+#if !ISMOBILE
     while(w>3 && textwidth(w, achievementMessage[1]) > vid.xres) w--;
 #endif
     displayfr(vid.xres/2, vid.yres/4 + vid.fsize*2, 2, w, achievementMessage[1], col, 8);
     w = vid.fsize;
-#if ISMOBILE==0
+#if !ISMOBILE
     while(w>3 && textwidth(w, achievementMessage[2]) > vid.xres) w--;
 #endif
     displayfr(vid.xres/2, vid.yres/4 + vid.fsize*4, 2, w, achievementMessage[2], col, 8);

--- a/arbitrile.cpp
+++ b/arbitrile.cpp
@@ -380,7 +380,7 @@ void connection_debugger() {
     string cap = its(k) + primes(last.second) + " -> " + its(get<0>(con)) + primes(get<1>(con)) + (get<2>(con) ? " (m) " : "");
     dialog::addSelItem(cap, "go", '0' + k);
     
-    dialog::add_action([k, last, &sh, con] {
+    dialog::add_action([k, last, con] {
       debug_polys.emplace_back(last.first * get_adj(debugged, last.second, k, -1), get<0>(con));
       });
     

--- a/binary-tiling.cpp
+++ b/binary-tiling.cpp
@@ -9,11 +9,17 @@
 namespace hr {
 
 EX namespace bt {
-#if CAP_BT
 
   /** note: nihsolv and kd3 tilings return bt::in(). They are defined elsewhere, although some of bt:: functions are used for them */
-  EX bool in() { return cgflags & qBINARY; }
+  EX bool in() {
+#if CAP_BT
+    return cgflags & qBINARY;
+#else
+    return false;
+#endif
+    }
   
+#if CAP_BT
   #if HDR
   enum bindir {
     bd_right = 0,

--- a/complex.cpp
+++ b/complex.cpp
@@ -3848,12 +3848,12 @@ EX namespace halloween {
       }
     int id = hrand(100);
     if(items[itTreat] == 1) {
-#if ISMOBILE==0
+#if !ISMOBILE
       addMessage(XLAT("Hint: use arrow keys to scroll."));
 #endif
       }
     else if(items[itTreat] == 2) {
-#if ISMOBILE==0
+#if !ISMOBILE
       addMessage(XLAT("Hint: press 1 2 3 4 to change the projection."));
 #endif
       }

--- a/complex2.cpp
+++ b/complex2.cpp
@@ -8,7 +8,7 @@
  */
 
 #include "hyper.h"
-#ifdef CAP_COMPLEX2
+#if CAP_COMPLEX2
 
 namespace hr {
 

--- a/config.cpp
+++ b/config.cpp
@@ -1269,36 +1269,34 @@ EX void configureOther() {
 
   // dialog::addBoolItem_action(XLAT("forget faraway cells"), memory_saving_mode, 'y');
   
-  #if CAP_AUDIO
-  if(CAP_AUDIO) {
-    dialog::addSelItem(XLAT("background music volume"), its(musicvolume), 'b');
-    dialog::add_action([] {
-      dialog::editNumber(musicvolume, 0, 128, 10, 60, XLAT("background music volume"), "");
-      dialog::reaction = [] () {
-        #if CAP_SDLAUDIO
-        Mix_VolumeMusic(musicvolume);
-        #endif
-        #if ISANDROID
-        settingsChanged = true;
-        #endif
-        };
-      dialog::bound_low(0);
-      dialog::bound_up(MIX_MAX_VOLUME);
-      });
+#if CAP_AUDIO
+  dialog::addSelItem(XLAT("background music volume"), its(musicvolume), 'b');
+  dialog::add_action([] {
+    dialog::editNumber(musicvolume, 0, 128, 10, 60, XLAT("background music volume"), "");
+    dialog::reaction = [] () {
+#if CAP_SDLAUDIO
+      Mix_VolumeMusic(musicvolume);
+#endif
+#if ISANDROID
+      settingsChanged = true;
+#endif
+      };
+    dialog::bound_low(0);
+    dialog::bound_up(MIX_MAX_VOLUME);
+    });
 
-    dialog::addSelItem(XLAT("sound effects volume"), its(effvolume), 'e');
-    dialog::add_action([] {
-      dialog::editNumber(effvolume, 0, 128, 10, 60, XLAT("sound effects volume"), "");
-      dialog::reaction = [] () {
-        #if ISANDROID
-        settingsChanged = true;
-        #endif
-        };
-      dialog::bound_low(0);
-      dialog::bound_up(MIX_MAX_VOLUME);
-      });
-    }
-  #endif
+  dialog::addSelItem(XLAT("sound effects volume"), its(effvolume), 'e');
+  dialog::add_action([] {
+    dialog::editNumber(effvolume, 0, 128, 10, 60, XLAT("sound effects volume"), "");
+    dialog::reaction = [] () {
+#if ISANDROID
+      settingsChanged = true;
+#endif
+      };
+    dialog::bound_low(0);
+    dialog::bound_up(MIX_MAX_VOLUME);
+    });
+#endif
 
   menuitem_sightrange('r');
 
@@ -1317,12 +1315,10 @@ EX void configureInterface() {
   gamescreen(3);
   dialog::init(XLAT("interface"));
 
-  #if CAP_TRANS
-  if(CAP_TRANS) {
-    dialog::addSelItem(XLAT("language"), XLAT("EN"), 'l');
-    dialog::add_action_push(selectLanguageScreen);
-    }
-  #endif
+#if CAP_TRANS
+  dialog::addSelItem(XLAT("language"), XLAT("EN"), 'l');
+  dialog::add_action_push(selectLanguageScreen);
+#endif
 
   dialog::addSelItem(XLAT("player character"), numplayers() > 1 ? "" : csname(vid.cs), 'g');
   dialog::add_action_push(showCustomizeChar);
@@ -2312,11 +2308,9 @@ EX void showSettings() {
   dialog::addItem(XLAT("colors & aura"), 'c');
   dialog::add_action_push(show_color_dialog);
 
-#if CAP_SHMUP
-  if(CAP_SHMUP && !ISMOBILE) {
-    dialog::addSelItem(XLAT("keyboard & joysticks"), "", 'k');
-    dialog::add_action(multi::configure);
-    }
+#if CAP_SHMUP && !ISMOBILE
+  dialog::addSelItem(XLAT("keyboard & joysticks"), "", 'k');
+  dialog::add_action(multi::configure);
 #endif
 
   dialog::addSelItem(XLAT("mouse & touchscreen"), "", 'm');

--- a/config.cpp
+++ b/config.cpp
@@ -800,7 +800,7 @@ EX void saveConfig() {
     fprintf(f, "%s=%s\n", s->name.c_str(), s->save().c_str());
   
   fclose(f);
-#if ISMOBILE==0
+#if !ISMOBILE
   addMessage(s0 + "Configuration saved to: " + conffile);
 #else
   addMessage(s0 + "Configuration saved");

--- a/control.cpp
+++ b/control.cpp
@@ -1021,7 +1021,7 @@ EX void mainloop() {
 #endif
   }
 
-#if ISMOBILE==1
+#if ISMOBILE
 EX void displayabutton(int px, int py, string s, int col) {
   // TMP
   int siz = vid.yres > vid.xres ? vid.fsize*2 : vid.fsize * 3/2;

--- a/dialogs.cpp
+++ b/dialogs.cpp
@@ -803,7 +803,7 @@ EX namespace dialog {
     else
       addSlider(ne.sc.direct(ne.vmin), ne.sc.direct(*ne.editwhat), ne.sc.direct(ne.vmax), 500);
     addBreak(100);
-#if ISMOBILE==0
+#if !ISMOBILE
     addHelp(XLAT("You can scroll with arrow keys -- Ctrl to fine-tune"));
     addBreak(100);
 #endif

--- a/drawing.cpp
+++ b/drawing.cpp
@@ -239,7 +239,7 @@ EX void glflush() {
   }
 #endif
 
-#if ISMOBILE==0
+#if !ISMOBILE
 SDL_Surface *aux;
 #endif
 
@@ -1661,7 +1661,7 @@ void dqi_poly::draw() {
       }
   #endif
   
-  #if CAP_SVG==1
+  #if CAP_SVG
     if(svg::in) {
       coords_to_poly();
       color_t col = color;
@@ -1678,10 +1678,10 @@ void dqi_poly::draw() {
   
     coords_to_poly();
   
-  #if CAP_XGD==1
+  #if CAP_XGD
     gdpush(1); gdpush(color); gdpush(outline); gdpush(polyi);
     for(int i=0; i<polyi; i++) gdpush(polyx[i]), gdpush(polyy[i]);
-  #elif CAP_SDLGFX==1
+  #elif CAP_SDLGFX
   
     if(tinf) {
       #if CAP_TEXTURE
@@ -1803,7 +1803,7 @@ void dqi_string::draw() {
     return;
     }
   #endif
-  #if ISMOBILE==0
+  #if !ISMOBILE
   int fr = frame & 255;
   displayfrSP(x, y, shift, fr, size, str, color, align, frame >> 8);
   #else

--- a/geometry.cpp
+++ b/geometry.cpp
@@ -433,16 +433,16 @@ hpcshape
     ld alpha;
     int area;
     };
-  shared_ptr<gpdata_t> gpdata;
+  shared_ptr<gpdata_t> gpdata = nullptr;
   #endif
   
-  int state;
-  int usershape_state;
+  int state = 0;
+  int usershape_state = 0;
 
   /** contains the texture point coordinates for 3D models */
   basic_textureinfo models_texture;
   
-  geometry_information() { last = NULL; state = usershape_state = 0; gpdata = NULL; }
+  geometry_information() { last = NULL; }
   
   void require_basics() { if(state & 1) return; state |= 1; prepare_basics(); }
   void require_shapes() { if(state & 2) return; state |= 2; prepare_shapes(); }

--- a/glhr.cpp
+++ b/glhr.cpp
@@ -24,10 +24,6 @@ EX void glError(const char* GLcall, const char* file, const int line) {
     }
   }
 
-#ifndef CAP_VERTEXBUFFER
-#define CAP_VERTEXBUFFER (ISWEB)
-#endif
-
 #if HDR
 #if CAP_SHADER && CAP_NOSHADER
 #define WITHSHADER(x, y) if(glhr::noshaders) y else x

--- a/graph.cpp
+++ b/graph.cpp
@@ -4052,7 +4052,7 @@ EX void queuecircleat(cell *c, double rad, color_t col) {
   }
 #endif
 
-#if ISMOBILE==1
+#if ISMOBILE
 #define MOBON (clicked)
 #else
 #define MOBON true

--- a/help.cpp
+++ b/help.cpp
@@ -357,7 +357,7 @@ EX string generateHelpForItem(eItem it) {
        " You need to go deep to collect lots of them.");
      }
      
-#if ISMOBILE==1
+#if ISMOBILE
    if(it == itOrbSafety)
      help += XLAT("This might be very useful for devices with limited memory.");
 #else
@@ -525,7 +525,7 @@ void addMinefieldExplanation(string& s) {
     );
 
   s += "\n\n";
-#if ISMOBILE==0
+#if !ISMOBILE
   s += XLAT("Known mines may be marked by pressing 'm'. Your allies won't step on marked mines.");
 #else
   s += XLAT("Known mines may be marked by touching while in drag mode. Your allies won't step on marked mines.");

--- a/hyper.h
+++ b/hyper.h
@@ -731,7 +731,7 @@ struct colortable: vector<color_t> {
 
 namespace scores { void load(); }
 
-#if ISMOBILE==1
+#if ISMOBILE
 namespace leader { void showMenu(); void handleKey(int sym, int uni); }
 #endif
 
@@ -740,7 +740,7 @@ int textwidth(int siz, const string &str);
 int gl_width(int size, const char *s);
 #endif
 
-#ifdef ISMOBILE
+#if ISMOBILE
 extern int andmode;
 extern bool longclick;
 extern bool useRangedOrb;

--- a/hyperweb.cpp
+++ b/hyperweb.cpp
@@ -30,10 +30,6 @@
 #define EMSCRIPTEN
 #endif
 
-#ifndef CAP_ORIENTATION
-#define CAP_ORIENTATION 1
-#endif
-
 #ifdef FAKEWEB
 namespace hr { void mainloopiter(); }
 template<class A, class B, class C> void emscripten_set_main_loop(A a, B b, C c) { while(true) mainloopiter(); }

--- a/inventory.cpp
+++ b/inventory.cpp
@@ -588,7 +588,7 @@ EX namespace inv {
           displaystr(vid.xres/2, vid.yres - vid.fsize*6, 2, vid.fsize, osminfo(which), icol, 8);
           }
 
-#if ISMOBILE==0
+#if !ISMOBILE
         string hot = XLAT1("Hotkey: "); hot += getcstat;
         displaystr(vid.xres/2, vid.yres - vid.fsize*5, 2, vid.fsize, hot, icol, 8);
 #endif

--- a/items.cpp
+++ b/items.cpp
@@ -467,7 +467,7 @@ EX void gainItem(eItem it) {
   if(chaosmode && gold() >= 300)
     achievement_gain_once("CHAOS", rg::chaos);
 
-#if ISMOBILE==1
+#if ISMOBILE
   if(g < lastsafety + R30*3/2 && g2 >= lastsafety + R30*3/2)
     addMessage(XLAT("The Orb of Safety from the Land of Eternal Motion might save you."));
 #endif

--- a/menus.cpp
+++ b/menus.cpp
@@ -230,7 +230,7 @@ EX void showMainMenu() {
   dialog::addItem(XLAT(inSpecialMode() ? "reset special modes" : "back to the start menu"), 'R');
   
   string q;
-  #if ISMOBILE==1
+  #if ISMOBILE
   dialog::addItem(XLAT("visit the website"), 'q');
   #else
   q = quitsaves() ? "save" : "quit"; 
@@ -248,7 +248,7 @@ EX void showMainMenu() {
   if(inv::on)
     dialog::addItem(XLAT("inventory"), 'i');    
 
-#if ISMOBILE==1
+#if ISMOBILE
 #if CAP_ACHIEVE
   dialog::addItem(XLAT("leaderboards/achievements"), '3'); 
 #endif
@@ -305,7 +305,7 @@ EX void showMainMenu() {
 #endif
     else if(sym == SDLK_ESCAPE) 
       showMissionScreen();
-  #if ISMOBILE==1
+  #if ISMOBILE
   #ifdef HAVE_ACHIEVEMENTS
     else if(NUMBERKEY == '3') {
       achievement_final(false);
@@ -382,7 +382,7 @@ EX void enable_cheat() {
   else if(!cheater) dialog::cheat_if_confirmed([] {
     cheater++;
     addMessage(XLAT("You activate your demonic powers!"));
-#if ISMOBILE==0
+#if !ISMOBILE
     addMessage(XLAT("Shift+F, Shift+O, Shift+T, Shift+L, Shift+U, etc."));
 #endif
     popScreen();

--- a/mobile.cpp
+++ b/mobile.cpp
@@ -44,7 +44,7 @@ string buildScoreDescription() {
   }
 #endif
 
-#if ISMOBILE==1
+#if ISMOBILE
 
 int andmode;
 

--- a/multi.cpp
+++ b/multi.cpp
@@ -549,7 +549,7 @@ EX void initConfig() {
   t[(int)'s'] = 16 + 6;
   t[(int)'a'] = 16 + 7;
 
-#if ISMOBILE==0
+#if !ISMOBILE
   t[SDLK_KP8] = 16 + 4;
   t[SDLK_KP6] = 16 + 5;
   t[SDLK_KP2] = 16 + 6;
@@ -572,7 +572,7 @@ EX void initConfig() {
   t[(int)'p'] = 32 + 10;
   t[(int)'['] = 32 + pcCenter;
 
-#if ISMOBILE==0
+#if !ISMOBILE
   t[SDLK_UP] = 48 ;
   t[SDLK_RIGHT] = 48 + 1;
   t[SDLK_DOWN] = 48 + 2;

--- a/quit.cpp
+++ b/quit.cpp
@@ -122,7 +122,7 @@ EX hint hints[] = {
     []() { return true; },
     []() { 
       dialog::addInfo(XLAT(
-#if ISMOBILE==1
+#if ISMOBILE
         "The 'world overview' shows all the lands in HyperRogue."
 #else
         "Press 'o' to see all the lands in HyperRogue."
@@ -457,12 +457,12 @@ EX void showMission() {
       dialog::addItem(XLAT("inventory"), 'i');
     if(racing::on)
       dialog::addItem(XLAT("racing menu"), 'o');
-    #if ISMOBILE==0
+#if !ISMOBILE
     dialog::addItem(XLAT(quitsaves() ? "save" : "quit"), SDLK_F10);
-    #endif
-    #if CAP_ANDROIDSHARE
+#endif
+#if CAP_ANDROIDSHARE
     dialog::addItem(XLAT("SHARE"), 's'-96);
-    #endif
+#endif
     }
   dialog::addItem(XLAT("message log"), 'l');
   

--- a/reg3.cpp
+++ b/reg3.cpp
@@ -282,6 +282,7 @@ EX namespace reg3 {
     return Id;
     }
     
+#if CAP_CRYSTAL
   int encode_coord(const crystal::coord& co) {
     int c = 0;
     for(int i=0; i<4; i++) c |= ((co[i]>>1) & 3) << (2*i);
@@ -314,6 +315,7 @@ EX namespace reg3 {
         }
       }        
     };
+#endif
 
   struct hrmap_field3 : reg3::hrmap_quotient3 {
   

--- a/rogueviz/newconf.cpp
+++ b/rogueviz/newconf.cpp
@@ -4,14 +4,7 @@
 
 #include "../hyper.h"
 
-#ifndef CAP_NCONF
-#define CAP_NCONF 0
-#endif
-
 #if CAP_NCONF
-#ifndef CAP_DRAW
-#define CAP_DRAW 0
-#endif
 #define main nconf_main
 #undef unordered_map
 #undef self

--- a/rogueviz/rogueviz.cpp
+++ b/rogueviz/rogueviz.cpp
@@ -913,10 +913,6 @@ void close() {
   relmatrices.clear();
   }
 
-#ifndef CAP_RVSLIDES
-#define CAP_RVSLIDES (CAP_TOUR && !ISWEB)
-#endif
-
 #if CAP_COMMANDLINE
 int readArgs() {
   using namespace arg;

--- a/rug.cpp
+++ b/rug.cpp
@@ -1624,8 +1624,10 @@ EX void show() {
     else if(uni == 'n' && !rug::rugged) 
       pushScreen(rug_geometry_choice);
     #endif
-    else if(uni == 'g' && !rug::rugged && CAP_SDL)
+#if CAP_SDL
+    else if(uni == 'g' && !rug::rugged)
       rendernogl = !rendernogl;
+#endif
     else if(uni == 's') {
       texturesize *= 2;
       if(texturesize == 8192) texturesize = 64;

--- a/savemem.cpp
+++ b/savemem.cpp
@@ -285,7 +285,7 @@ EX void show_memory_menu() {
   }
 
 EX bool protect_memory() {
-  if(!CAP_MEMORY_RESERVE) return false;
+#if CAP_MEMORY_RESERVE
   apply_memory_reserve();
   if(reserve_limit && reserve_count < reserve_limit && !ignored_memory_warning) {
     pushScreen(show_memory_menu);
@@ -295,6 +295,7 @@ EX bool protect_memory() {
     pushScreen(show_memory_menu);
     return true;
     }
+#endif
   return false;
   }
 

--- a/screenshot.cpp
+++ b/screenshot.cpp
@@ -358,13 +358,14 @@ EX always_false in;
   /** 0 = no/unknown/disabled texture, 1 = rug, 2 = gradient, 3 = floor texture */
   EX int texture_type(dqi_poly& p) {
     if(!p.tinf) return 0;
-    if(!CAP_PNG) return 0;
+#if CAP_PNG
     if(!textures) return 0;
     if(p.tinf == &rug::tinf) return 1;
     #if MAXMDIM >= 4
     if(p.tinf->texture_id == (int) floor_textures->renderedTexture)
       return (p.tinf->tvertices[0][0] == 0) ? 2 : 3;
     #endif
+#endif
     return 0;
     }
 
@@ -1730,8 +1731,13 @@ startanim perspective { "projection distance", no_init, [] {
   }};
 
 startanim rug { "Hypersian Rug", [] { 
-  if(!CAP_RUG) { pick(); return; }
-  rug::init(), rug::rugged = false; }, [] {
+#if CAP_RUG
+  rug::init();
+  rug::rugged = false;
+#else
+  pick();
+#endif
+  }, [] {
   dynamicval<bool> b(rug::rugged, true);
   rug::physics();
   dynamicval<transmatrix> t(rug::rugView, cspin(1, 2, ticks / 3000.) * rug::rugView);

--- a/surface.cpp
+++ b/surface.cpp
@@ -370,10 +370,6 @@ int dexp_comb_colors[16] = {
 int coverage_style;
 EX vector<pair<hyperpoint, int> > coverage;
 
-#ifndef CAP_KUEN_MAP
-#define CAP_KUEN_MAP 0
-#endif
-
 #if CAP_KUEN_MAP
 void draw_kuen_map() {
   SDL_Surface *kuen_map = SDL_CreateRGBSurface(SDL_SWSURFACE,512,512,32,0,0,0,0);

--- a/sysconfig.h
+++ b/sysconfig.h
@@ -407,7 +407,6 @@ extern "C" {
 #define CAP_GLEW (CAP_GL && !ISMOBILE && !ISMAC && !ISLINUX && !ISWEB)
 #endif
 
-#if CAP_GL
 #if CAP_GLEW
   #include <GL/glew.h>
 #else
@@ -429,7 +428,6 @@ extern "C" {
     #include <GL/gl.h>
     #include <GL/glu.h>
     #include <GL/glext.h>
-    #endif
   #endif
 #endif
 

--- a/sysconfig.h
+++ b/sysconfig.h
@@ -63,6 +63,14 @@
 #define ISMINI 0
 #endif
 
+#ifndef CAP_NCONF
+#define CAP_NCONF 0
+#endif
+
+#ifndef CAP_DRAW
+#define CAP_DRAW 0
+#endif
+
 #ifndef CAP_XGD
 #define CAP_XGD (ISANDROID || ISFAKEMOBILE)
 #endif
@@ -83,6 +91,10 @@
 
 #ifndef NOLICENSE
 #define NOLICENSE ISSTEAM
+#endif
+
+#ifndef CAP_VERTEXBUFFER
+#define CAP_VERTEXBUFFER (ISWEB)
 #endif
 
 #ifndef CAP_SHADER
@@ -153,6 +165,10 @@
 #define CAP_SURFACE CAP_RUG
 #endif
 
+#ifndef CAP_KUEN_MAP
+#define CAP_KUEN_MAP 0
+#endif
+
 #ifndef CAP_EDIT
 #define CAP_EDIT (CAP_FILES && !ISWEB && !ISMINI)
 #endif
@@ -197,6 +213,10 @@
 #define CAP_ROGUEVIZ 0
 #endif
 
+#ifndef CAP_RVSLIDES
+#define CAP_RVSLIDES (CAP_TOUR && !ISWEB)
+#endif
+
 #ifndef CAP_PROFILING
 #define CAP_PROFILING 0
 #endif
@@ -210,7 +230,7 @@
 #endif
 
 #ifndef CAP_ORIENTATION
-#define CAP_ORIENTATION ISMOBILE
+#define CAP_ORIENTATION (ISMOBILE || ISWEB)
 #endif
 
 #ifndef CAP_MOUSEGRAB

--- a/system.cpp
+++ b/system.cpp
@@ -1068,7 +1068,7 @@ EX void saveStats(bool emergency IS(false)) {
   
   fprintf(f, "\n\n\n");
   
-#if ISMOBILE==0
+#if !ISMOBILE
   DEBB(DF_INIT, ("Game statistics saved to ", scorefile));
   addMessage(XLAT("Game statistics saved to %1", scorefile));
 #endif
@@ -1556,7 +1556,7 @@ EX void finishAll() {
   saveStats();
 #endif
   clearMemory();
-#if ISMOBILE==0
+#if !ISMOBILE
   cleargraph();
 #endif
   


### PR DESCRIPTION
- The phrase `#ifdef CAP_` should never appear anywhere.

- The phrase `#ifndef CAP_` should appear only in sysconfig.h.

- The phrases `#if CAP_` and `#if !CAP_` may appear wherever,
    as long as "sysconfig.h" is included first.

The rules for `CAP_FOO` equally apply to `ISFOO`.

There are many one-off macros still tested with `#ifdef`,
including `HAVE_ACHIEVEMENTS`, `PRINT_ACHIEVEMENTS`,
`FAKEWEB`, `FAKE_SDL`, `EASY`, and `WHATEVER`. I don't
have much grasp on what these are used for or how they're
configured, so I'm leaving them alone.