### PR TITLE
Some fixes to mymake and Makefile.simple

### DIFF
--- a/Makefile.simple
+++ b/Makefile.simple
@@ -152,7 +152,7 @@ langen$(EXE_EXTENSION): langen.cpp language-??.cpp language-ptbr.cpp
 makeh$(EXE_EXTENSION): makeh.cpp
 	$(CXX) -O2 makeh.cpp -o $@
 
-autohdr.h: makeh$(EXE_EXTENSION) *.cpp
+autohdr.h: makeh$(EXE_EXTENSION) language-data.cpp *.cpp
 	./makeh classes.cpp locations.cpp hyperpoint.cpp geometry.cpp goldberg.cpp init.cpp floorshapes.cpp cell.cpp multi.cpp shmup.cpp pattern2.cpp mapeditor.cpp graph.cpp textures.cpp hprint.cpp language.cpp util.cpp complex.cpp *.cpp > autohdr.h
 
 language-data.cpp: langen$(EXE_EXTENSION)

--- a/mymake.cpp
+++ b/mymake.cpp
@@ -94,7 +94,7 @@ int main(int argc, char **argv) {
       obj_dir += "/";
       setdir += "../";
       for(char c: s) 
-        if(c == '=' || c == '-' || c == '/') obj_dir += "_"; 
+        if(c == '=' || c == '-' || c == '/' || c == '"' || c == '\\') obj_dir += "_"; 
         else obj_dir += c;      
       }
     else if(s == "-win") {

--- a/mymake.cpp
+++ b/mymake.cpp
@@ -83,8 +83,10 @@ int main(int argc, char **argv) {
   set_linux();
 #endif
   for(string fname: {"Makefile.loc", "Makefile.simple", "Makefile"})
-    if(file_exists(fname))
+    if(file_exists(fname)) {
       system("make -f " + fname + " language-data.cpp autohdr.h savepng.o");
+      break;
+      }
   for(int i=1; i<argc; i++) {
     string s = argv[i];
     if(s.substr(0, 2) == "-D") {


### PR DESCRIPTION
Just a simple override in case there is a `-jN` parameter in `MAKEFLAGS`. This seems necessary, because otherwise `./makeh` could be executed before `./langen` despite the former needing the latter's output.