### PR TITLE
Add basic highlighting of enemies on the horizon

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -340,6 +340,7 @@ EX void initConfig() {
   addsaver(pconf.ballproj, "ballproj", 1);
   addsaver(vid.monmode, "monster display mode", DEFAULT_MONMODE);
   addsaver(vid.wallmode, "wall display mode", DEFAULT_WALLMODE);
+  addsaver(vid.faraway_highlight, "highlight faraway monsters", false);
 
   addsaver(vid.depth, "3D depth", 1);
   addsaver(vid.camera, "3D camera level", 1);
@@ -1303,6 +1304,8 @@ EX void configureOther() {
 #endif
 
   menuitem_sightrange('r');
+
+  dialog::addBoolItem_action(XLAT("highlight faraway monsters"), vid.faraway_highlight, 'h');
 
 #ifdef WHATEVER
   dialog::addSelItem(XLAT("whatever"), fts(whatever[0]), 'j');

--- a/graph.cpp
+++ b/graph.cpp
@@ -2436,7 +2436,22 @@ EX bool drawMonster(const transmatrix& Vparam, int ct, cell *c, color_t col, col
       (isPlayerOn(c) || isFriendly(c)) ? OUTLINE_FRIEND : 
       noHighlight(c->monst) ? OUTLINE_NONE :
       OUTLINE_ENEMY;
-    
+
+  // highlight faraway enemies if that's needed
+  if (vid.faraway_highlight) {
+    bool need_highlight = isActiveEnemy(c, moPlayer) && c->cpdist >= 6;
+    if (need_highlight) {
+      int hd;
+      if (c->cpdist >= 7) hd = 1;
+      else hd = 3;
+      // basic red-green oscillation
+      color_t r = ceil(255*abs(sintick(1000, 0.25))) / hd;
+      color_t g = ceil(255*abs(sintick(1000, 0.00))) / hd;
+      color_t hlc = (r<<16) + (g<<8);
+      addauraspecial(tC0(Vparam), hlc, 0);
+      }
+    }
+
   bool nospins = false, nospinb = false;
   double footphaseb = 0, footphase = 0;
   

--- a/hyper.h
+++ b/hyper.h
@@ -367,6 +367,8 @@ struct videopar {
   ld plevel_factor;
   bool bubbles_special, bubbles_threshold, bubbles_all;
   int joysmooth;
+
+  bool faraway_highlight; // draw attention to monsters on the horizon
   };
 
 extern videopar vid;


### PR DESCRIPTION
So the cells at the edge of the map (at least in the usual Poincare model) are tiny, making it kind of hard to notice monsters there. Of course, Alt-highlight and high contrast modes already exist, but, at least for me, they didn't help all that much. Both suffer from the fact that the highlighted shape is still tiny. Also, they are static.

Cue one of the simplest possible solutions: use "special aura" with an oscillating color to draw attention to monsters you could otherwise overlook. One possible caveat is that other things also use it, so there may be conflicts. I'm not even completely sure that drawMonster(...) is the right place for that.

In all, the code with this PR is probably not all that important (it's likely ignoring many non-standard cases anyway). Obviously there is more than one way to approach the outlined problem, so I hope it should at least stimulate the discussion.