### PR TITLE
Attempt to convince mymake to work on MinGW

### DIFF
--- a/.github/workflows/test_simple.sh
+++ b/.github/workflows/test_simple.sh
@@ -6,6 +6,7 @@ if [[ "$GH_OS" == "windows-latest" && "$GH_BUILDSYS" == "mymake" ]]; then
 cat << ENDOFCMDS > .github/workflows/gdb_cmds.txt
   run --version
   backtrace
+  exit 1
 ENDOFCMDS
 
   gdb --batch -x .github/workflows/gdb_cmds.txt ./hyperrogue

--- a/mymake.cpp
+++ b/mymake.cpp
@@ -91,9 +91,11 @@ int main(int argc, char **argv) {
 #else
   set_linux();
 #endif
+  int retval = 0; // for storing return values of some function calls
   for(string fname: {"Makefile.loc", "Makefile.simple", "Makefile"})
     if(file_exists(fname)) {
-      system("make -f " + fname + " language-data.cpp autohdr.h savepng.o");
+      retval = system("make -f " + fname + " language-data.cpp autohdr.h savepng.o");
+      if (retval) { printf("error during preparation!\n"); exit(retval); }
       break;
       }
   for(int i=1; i<argc; i++) {
@@ -173,7 +175,8 @@ int main(int argc, char **argv) {
   compiler += " " + standard;
   ifstream fs("hyper.cpp");
 
-  system("mkdir -p " + obj_dir);
+  retval = system("mkdir -p " + obj_dir);
+  if (retval) { printf("unable to create output directory!\n"); exit(retval); }
 
   ofstream fsm(obj_dir + "/hyper.cpp");
   fsm << "#if REM\n#define INCLUDE(x)\n#endif\n";
@@ -271,9 +274,13 @@ int main(int argc, char **argv) {
     else if (tasks_done == tasks_amt) { finished = true; break; }
     } this_thread::sleep_for(quantum); }
 
-  if (mingw64) (void)system("windres hyper.rc -O coff -o hyper.res");
+  if (mingw64) {
+    retval = system("windres hyper.rc -O coff -o hyper.res");
+    if (retval) { printf("windres error!\n"); exit(retval); }
+    }
 
   printf("linking...\n");
-  system(linker + allobj + libs);
+  retval = system(linker + allobj + libs);
+  if (retval) { printf("linking error!\n"); exit(retval); }
   return 0;
   }


### PR DESCRIPTION
...has not been as successful as I'd hoped. Short version: build runs just fine, but program segfaults upon launch.

Setup: MinGW64 under MSYS2 of latest version as of writing. Necessary packages installed (btw, I could probably try to make a config for Travis with this setup; looking at Travis docs it didn't seem too difficult).
Preliminary note: builds with `automake` and `Makefile.simple` both work fine. At least no segfault at launch.

A bit about proposed changes to `mymake.cpp`. I based the configuration off of `Makefile.simple`. Options such as `-DCAP_PNG` are just temporarily there, as per #107.
As for renaming `win` to `mingw64`, this was to be more specific _just_ in case there are other Windows build profiles. Also, `system(cmd)` on MinGW is peculiar and required a workaround. It's really only needed for `mkdir` and `windres`, but I don't think it hurts everywhere else.

And now, the segfaults. I tried different permutations and combinations of options, but the result is the same: `hyper.exe`, if ran from MinGW shell, segfaults straight away. Not even `--help` option works. And ran natively from Windows (double-clicking the file, that is) it opens a console window, where usually the various debug info would be printed, prints nothing, hangs for a second, and closes.

Running from under MinGW, `gdb` shows that segfaults occur in different functions sometimes, but all of them have "dunder" names, which AFAIK means that these are a part of the C++ runtime. I'll post backtraces (and whatever else is required) in a bit. Admittedly, I don't know all that much about MinGW or C++ in general, so apologies for not knowing what info exactly to provide.

With that said, I came across something called "static initialization order fiasco", but I'm not sure it's relevant. One of the segfault cases did involve a function `__static_initialization_and_destruction_0(int, int)`, though.

And that's all for now, I think.