### PR TITLE
Add Travis configuration for MinGW64 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -132,6 +132,22 @@ before_install:
     brew install sdl sdl_gfx sdl_mixer sdl_ttf
     # work around https://stackoverflow.com/questions/51034399/ for now
     (cd /usr/local/include && ln -sf SDL/SDL.h)
+  elif [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+    [[ ! -f C:/tools/msys64/msys2_shell.cmd ]] && rm -rf C:/tools/msys64
+    choco uninstall -y mingw
+    choco upgrade --no-progress -y msys2
+    export msys2='cmd //C RefreshEnv.cmd '
+    export msys2+='& set MSYS=winsymlinks:nativestrict '
+    export msys2+='& C:\\tools\\msys64\\msys2_shell.cmd -defterm -no-start'
+    export mingw64="$msys2 -mingw64 -full-path -here -c "\"\$@"\" --"
+    export msys2+=" -msys2 -c "\"\$@"\" --"
+    $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-toolchain
+    ## Install more MSYS2 packages from https://packages.msys2.org/base here
+    $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-SDL mingw-w64-x86_64-SDL_gfx mingw-w64-x86_64-SDL_mixer mingw-w64-x86_64-SDL_ttf
+    taskkill //IM gpg-agent.exe //F  # https://travis-ci.community/t/4967
+    taskkill //IM dirmngr.exe //F # this process also seemed to hang after install
+    export PATH=/C/tools/msys64/mingw64/bin:$PATH
+    export MAKE=mingw32-make  # so that Autotools can find it
   else
     exit 'Unsupported OS'
   fi
@@ -142,6 +158,8 @@ before_install:
       sudo apt-get install -qq libglew-dev
     elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       brew install glew
+    elif [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+      $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-glew
     else
       exit 'Unsupported OS'
     fi
@@ -153,6 +171,8 @@ before_install:
       echo 'libpng is installed by default'
     elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       brew install libpng
+    elif [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+      $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-libpng
     else
       exit 'Unsupported OS'
     fi
@@ -164,6 +184,8 @@ before_install:
       echo 'autotools is installed by default'
     elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       brew install automake
+    elif [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+      $msys2 pacman --sync --noconfirm --needed automake-wrapper
     else
       exit 'Unsupported OS'
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,6 +120,15 @@ matrix:
       HYPERROGUE_USE_GLEW=1
       HYPERROGUE_USE_PNG=1
       HYPERROGUE_USE_ROGUEVIZ=1
+  - os: windows
+    compiler: gcc
+    env: >-
+      TRAVIS_OS_NAME=windows
+      TRAVIS_COMPILER_NAME=gcc
+      TRAVIS_BUILD_SYSTEM=Makefile
+      HYPERROGUE_USE_GLEW=1
+      HYPERROGUE_USE_PNG=1
+      HYPERROGUE_USE_ROGUEVIZ=1
 
 before_install:
 - |-
@@ -199,7 +208,7 @@ script:
     ./configure CXXFLAGS="-W -Wall -Wextra -Werror -Wno-unused-parameter -Wno-maybe-uninitialized -Wno-unknown-warning-option"
     make
   elif [[ "$TRAVIS_BUILD_SYSTEM" == "Makefile" ]]; then
-    make -f Makefile.simple
+    $mingw64 make -f Makefile.simple
   elif [[ "$TRAVIS_BUILD_SYSTEM" == "mymake" ]]; then
     make -f Makefile.simple mymake
     if [[ "$HYPERROGUE_USE_ROGUEVIZ" == "1" ]]; then


### PR DESCRIPTION
Based on: https://docs.travis-ci.com/user/reference/windows/#how-do-i-use-msys2

Just one -- Makefile.simple -- job for now, since that seemed to work fine locally for me. Automake-build could also be added, but not sure of its necessity.