### PR TITLE
Proposal to add Github CI

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,0 +1,36 @@
+set -e o pipefail
+source .github/workflows/gh_ci_envvars.sh
+
+
+GH_MYMAKE_ARGS=""
+GH_AUTOTOOLS_CXXFLAGS="-W -Wall -Wextra -Wno-unused-parameter -Wno-maybe-uninitialized"
+
+HYPERROGUE_USE_GLEW=$GH_HYP_GLEW
+export HYPERROGUE_USE_GLEW=${HYPERROGUE_USE_GLEW: -1}
+
+HYPERROGUE_USE_PNG=$GH_HYP_PNG
+export HYPERROGUE_USE_PNG=${HYPERROGUE_USE_PNG: -1}
+
+HYPERROGUE_USE_ROGUEVIZ=$GH_HYP_RVIZ
+export HYPERROGUE_USE_ROGUEVIZ=${HYPERROGUE_USE_ROGUEVIZ: -1}
+if [[ "$GH_HYP_RVIZ" == "rviz_1" ]]; then
+  GH_MYMAKE_ARGS+=" -rv"
+  GH_AUTOTOOLS_CXXFLAGS+=" -DCAP_ROGUEVIZ=1"
+fi
+
+export CC=$GH_COMPILER
+export CXX=${CC%cc}++
+
+if [[ "$GH_BUILDSYS" == "makefile" ]]; then
+  make -f Makefile.simple
+elif [[ "$GH_BUILDSYS" == "autotools" ]]; then
+  autoreconf -vfi
+  ./configure CXXFLAGS="${GH_AUTOTOOLS_CXXFLAGS}"
+  make
+elif [[ "$GH_BUILDSYS" == "mymake" ]]; then
+  make -f Makefile.simple mymake
+  ./mymake $GH_MYMAKE_ARGS
+  mv hyper hyperrogue
+else
+  exit 'unknown build system'
+fi

--- a/.github/workflows/github_ci.yml
+++ b/.github/workflows/github_ci.yml
@@ -1,0 +1,80 @@
+name: Github CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  main_matrix:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        compiler: [gcc, clang]
+        build_system: [makefile, autotools, mymake]
+        hyper_use_rviz: [rviz_1, rviz_0]
+        hyper_use_png: [png_1]
+        hyper_use_glew: [glew_1]
+    steps:
+    - uses: actions/checkout@v2
+    - name: envvars_setup
+      run: |
+        cat << ENDOFVARS > .github/workflows/gh_ci_envvars.sh
+        GH_OS=${{ matrix.os }}
+        GH_COMPILER=${{ matrix.compiler }}
+        GH_BUILDSYS=${{ matrix.build_system }}
+        GH_HYP_RVIZ=${{ matrix.hyper_use_rviz }}
+        GH_HYP_PNG=${{ matrix.hyper_use_png }}
+        GH_HYP_GLEW=${{ matrix.hyper_use_glew }}
+        ENDOFVARS
+    - name: install_deps
+      run: .github/workflows/install_deps.sh
+    - name: build
+      run: .github/workflows/build.sh
+    - name: test_simple
+      run: .github/workflows/test_simple.sh
+
+  windows:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        compiler: [gcc]
+        build_system: [makefile, autotools]
+        hyper_use_rviz: [rviz_1, rviz_0]
+        hyper_use_png: [png_1]
+        hyper_use_glew: [glew_1]
+    steps:
+    - uses: actions/checkout@v2
+    - name: envvars_setup
+      shell: cmd.exe /D /E:ON /V:OFF /C "C:\msys64\msys2_shell.cmd -defterm -msys2 -no-start -full-path -here {0}"
+      run: |
+        cat << ENDOFVARS > .github/workflows/gh_ci_envvars.sh
+        GH_OS=${{ matrix.os }}
+        GH_COMPILER=${{ matrix.compiler }}
+        GH_BUILDSYS=${{ matrix.build_system }}
+        GH_HYP_RVIZ=${{ matrix.hyper_use_rviz }}
+        GH_HYP_PNG=${{ matrix.hyper_use_png }}
+        GH_HYP_GLEW=${{ matrix.hyper_use_glew }}
+        ENDOFVARS
+    - name: install_deps
+      run: cmd.exe /D /E:ON /V:OFF /C "C:\msys64\msys2_shell.cmd -defterm -msys2 -no-start -full-path -here .github/workflows/install_deps.sh"
+    - name: build
+      run: cmd.exe /D /E:ON /V:OFF /C "C:\msys64\msys2_shell.cmd -defterm -mingw64 -no-start -full-path -here .github/workflows/build.sh"
+    - name: test_simple
+      run: cmd.exe /D /E:ON /V:OFF /C "C:\msys64\msys2_shell.cmd -defterm -mingw64 -no-start -full-path -here .github/workflows/test_simple.sh"
+
+  emscripten:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: build
+      run: |
+        docker run --rm -v $(pwd):/src trzeci/emscripten make -f Makefile.simple emscripten
+    - name: test_simple
+      run: |
+        ls -lAF hyper.html hyper.js hyper.wasm

--- a/.github/workflows/install_deps.sh
+++ b/.github/workflows/install_deps.sh
@@ -1,0 +1,40 @@
+set -e o pipefail
+source .github/workflows/gh_ci_envvars.sh
+
+
+GH_DEPS_UBUNTU="$GH_COMPILER libsdl1.2-dev libsdl-ttf2.0-dev libsdl-gfx1.2-dev libsdl-mixer1.2-dev"
+GH_DEPS_MACOS="sdl sdl_gfx sdl_mixer sdl_ttf"
+GH_DEPS_MINGW64="$GH_COMPILER:x SDL:x SDL_ttf:x SDL_gfx:x SDL_mixer:x"
+
+if [[ "$GH_HYP_GLEW" == "glew_1" ]]; then
+  GH_DEPS_UBUNTU+=" libglew-dev"
+  GH_DEPS_MACOS+=" glew"
+  GH_DEPS_MINGW64+=" glew:x"
+fi
+
+if [[ "$GH_HYP_PNG" == "png_1" ]]; then
+  GH_DEPS_UBUNTU+=" libpng-dev"
+  GH_DEPS_MACOS+=" libpng"
+  GH_DEPS_MINGW64+=" libpng:x"
+fi
+
+if [[ "$GH_BUILDSYS" == "autotools" ]]; then
+  GH_DEPS_UBUNTU+=" autoconf"
+  GH_DEPS_MACOS+=" automake"
+  GH_DEPS_MINGW64+=" automake-wrapper autoconf"
+fi
+
+if [[ "$GH_OS" == "ubuntu-latest" ]]; then
+  sudo apt-get -y install $GH_DEPS_UBUNTU
+elif [[ "$GH_OS" == "macos-latest" ]]; then
+  brew update
+  # macos-latest already has both gcc and clang
+  brew install $GH_DEPS_MACOS
+  # work around https://stackoverflow.com/questions/51034399/ for now
+  (cd /usr/local/include && ln -sf SDL/SDL.h)
+elif [[ "$GH_OS" == "windows-latest" ]]; then
+  pacboy -Sy --noconfirm --needed $GH_DEPS_MINGW64
+  sed -i'.orig' 's/<SDL.h>/"SDL.h"/' /mingw64/include/SDL/SDL_gfxPrimitives.h
+else
+  exit 'unknown OS'
+fi

--- a/.github/workflows/test_simple.sh
+++ b/.github/workflows/test_simple.sh
@@ -1,0 +1,5 @@
+set -e o pipefail
+source .github/workflows/gh_ci_envvars.sh
+
+
+./hyperrogue --version


### PR DESCRIPTION
As it turns out, Github has its own CI system as part of "Actions". I'll leave it up to zenorogue to decide whether it's needed or worth it, but here is a more or less direct port of the current Travis configuration. It's not quite the same, of course: the main build matrix is every configuration of
`{MacOS, Ubuntu} x {GCC, clang} x {makefile, autotools, mymake} x {rogueviz, no rogueviz}`,
and `emscripten` build is separate from that matrix. This is just a simple configuration, of course it's up to discussion to decide what needs to be there and what doesn't. There is also a temporary hack disabling warnings->errors. I think that there exist ways to gather all warnings from a build without failing it, but I haven't looked into that yet.

[Example](https://github.com/rpljwi/hyperrogue/actions/runs/111604467) result using the configuration from the commit.

One note to zenorogue: if/when you do decide to add this, consider disabling notifications for actions. Otherwise tests may generate a lot of notifications/emails.