### PR TITLE
Add parallel compilation to mymake

### DIFF
--- a/Makefile.simple
+++ b/Makefile.simple
@@ -162,7 +162,7 @@ savepng$(OBJ_EXTENSION): savepng.cpp
 	$(CXX) -O2 $(CXXFLAGS) -c savepng.cpp -o $@
 
 mymake$(EXE_EXTENSION): mymake.cpp
-	$(CXX) -O2 $(CXXFLAGS) mymake.cpp -o $@
+	$(CXX) -O2 $(CXXFLAGS) -lpthread mymake.cpp -o $@
 
 emscripten: hyper.html
 

--- a/Makefile.simple
+++ b/Makefile.simple
@@ -162,7 +162,7 @@ savepng$(OBJ_EXTENSION): savepng.cpp
 	$(CXX) -O2 $(CXXFLAGS) -c savepng.cpp -o $@
 
 mymake$(EXE_EXTENSION): mymake.cpp
-	$(CXX) -O2 $(CXXFLAGS) -lpthread mymake.cpp -o $@
+	$(CXX) -O2 $(CXXFLAGS) mymake.cpp -lpthread -o $@
 
 emscripten: hyper.html
 

--- a/Makefile.simple
+++ b/Makefile.simple
@@ -162,7 +162,7 @@ savepng$(OBJ_EXTENSION): savepng.cpp
 	$(CXX) -O2 $(CXXFLAGS) -c savepng.cpp -o $@
 
 mymake$(EXE_EXTENSION): mymake.cpp
-	$(CXX) -O2 $(CXXFLAGS) mymake.cpp -lpthread -o $@
+	$(CXX) -O2 $(CXXFLAGS) mymake.cpp -pthread -o $@
 
 emscripten: hyper.html
 

--- a/mymake.cpp
+++ b/mymake.cpp
@@ -210,6 +210,8 @@ int main(int argc, char **argv) {
   
   string allobj = " " + obj_dir + "/hyper.o";
 
+  printf("compiling modules using batch size of %d:\n", batch_size);
+
   int id = 0;
   vector<pair<int, string>> tasks;
   for(string m: modules) {

--- a/mymake.cpp
+++ b/mymake.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <fstream>
 #include <iostream>
+#include <thread>
 #include <vector>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -239,17 +240,17 @@ int main(int argc, char **argv) {
     id++;
     }
 
-  chrono::milliseconds quantum(25);
+  chrono::milliseconds quantum(40);
   vector<future<int>> workers(batch_size);
 
   int tasks_amt = tasks.size();
   int tasks_taken = 0, tasks_done = 0;
   bool finished = tasks.empty();
 
-  while (!finished)
+  while (!finished) {
   for (auto & worker : workers) {
     if (worker.valid()) {
-      if (worker.wait_for(quantum) != future_status::ready) continue;
+      if (worker.wait_for(chrono::seconds(0)) != future_status::ready) continue;
       else {
         int res = worker.get();
         if (res) { printf("compilation error!\n"); exit(1); }
@@ -265,7 +266,7 @@ int main(int argc, char **argv) {
       ++tasks_taken;
       }
     else if (tasks_done == tasks_amt) { finished = true; break; }
-    }
+    } this_thread::sleep_for(quantum); }
   
   printf("linking...\n");
   system(linker + allobj + libs);

--- a/mymake.cpp
+++ b/mymake.cpp
@@ -29,7 +29,7 @@ string compiler;
 string linker;
 string libs;
 
-int batch_size = 1;
+int batch_size = thread::hardware_concurrency() + 1;
 
 void set_linux() {
   preprocessor = "g++ -E";
@@ -134,9 +134,7 @@ int main(int argc, char **argv) {
     else if(s.substr(0, 2) == "-l")
       linker += " " + s;
     else if(s.substr(0, 2) == "-j")
-      if (s.length() == 2 || stoi(s.substr(2)) < 1)
-        batch_size = thread::hardware_concurrency() + 1;
-      else batch_size = stoi(s.substr(2));
+      batch_size = stoi(s.substr(2));
     else if(s == "-I") {
       opts += " " + s + " " + argv[i+1];
       i++;

--- a/mymake.cpp
+++ b/mymake.cpp
@@ -248,17 +248,15 @@ int main(int argc, char **argv) {
 
   while (!finished)
   for (auto & worker : workers) {
-    check_lollygagging:
     if (worker.valid()) {
       if (worker.wait_for(quantum) != future_status::ready) continue;
       else {
         int res = worker.get();
         if (res) { printf("compilation error!\n"); exit(1); }
         ++tasks_done;
-        goto check_lollygagging;
         }
       }
-    else if (tasks_taken < tasks_amt) {
+    if (tasks_taken < tasks_amt) {
       auto task = tasks[tasks_taken];
       int mid = task.first;
       function<int(void)> do_work = task.second;


### PR DESCRIPTION
Dunning-Kruger effect is a really powerful thing, I guess. After discussing threaded approach in #118, I eventually decided that it's not as hard as it seems, and here is what I've come up with. Since I'm more out of my depth than usual here, all suggestions and corrections are especially welcome.

Before anything else, of course I tested it a couple of times, and nothing seemed to break thus far (including correct resumption after `SIGINT`). Total compilation time (including Rogueviz) on my 4-core system went down from 7:50 to 3:50 if using `-j` option, which should be equivalent to batch size of `$(nproc)+1`, which is often suggested for make.