### PR TITLE
Eliminate the option to pass -DCAP_PNG=0 on desktop.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ matrix:
       TRAVIS_COMPILER_NAME=gcc
       TRAVIS_BUILD_SYSTEM=autotools
       HYPERROGUE_USE_GLEW=1
-      HYPERROGUE_USE_PNG=1
   - os: osx
     compiler: clang
     env: >-
@@ -18,7 +17,6 @@ matrix:
       TRAVIS_COMPILER_NAME=clang
       TRAVIS_BUILD_SYSTEM=autotools
       HYPERROGUE_USE_GLEW=1
-      HYPERROGUE_USE_PNG=1
   - os: linux
     compiler: gcc
     env: >-
@@ -26,7 +24,6 @@ matrix:
       TRAVIS_COMPILER_NAME=gcc
       TRAVIS_BUILD_SYSTEM=Makefile
       HYPERROGUE_USE_GLEW=1
-      HYPERROGUE_USE_PNG=1
   - os: linux
     compiler: clang
     env: >-
@@ -34,7 +31,6 @@ matrix:
       TRAVIS_COMPILER_NAME=clang
       TRAVIS_BUILD_SYSTEM=Makefile
       HYPERROGUE_USE_GLEW=1
-      HYPERROGUE_USE_PNG=1
   - os: linux
     dist: bionic
     compiler: gcc
@@ -43,7 +39,6 @@ matrix:
       TRAVIS_COMPILER_NAME=gcc
       TRAVIS_BUILD_SYSTEM=Makefile
       HYPERROGUE_USE_GLEW=1
-      HYPERROGUE_USE_PNG=1
       HYPERROGUE_USE_ROGUEVIZ=1
   - os: linux
     compiler: clang
@@ -52,7 +47,6 @@ matrix:
       TRAVIS_COMPILER_NAME=clang
       TRAVIS_BUILD_SYSTEM=Makefile
       HYPERROGUE_USE_GLEW=1
-      HYPERROGUE_USE_PNG=1
       HYPERROGUE_USE_ROGUEVIZ=1
   - os: osx
     compiler: clang
@@ -61,7 +55,6 @@ matrix:
       TRAVIS_COMPILER_NAME=clang
       TRAVIS_BUILD_SYSTEM=Makefile
       HYPERROGUE_USE_GLEW=1
-      HYPERROGUE_USE_PNG=1
   - os: osx
     compiler: gcc
     env: >-
@@ -69,7 +62,6 @@ matrix:
       TRAVIS_COMPILER_NAME=gcc
       TRAVIS_BUILD_SYSTEM=Makefile
       HYPERROGUE_USE_GLEW=1
-      HYPERROGUE_USE_PNG=1
       HYPERROGUE_USE_ROGUEVIZ=1
   - os: osx
     compiler: clang
@@ -78,7 +70,6 @@ matrix:
       TRAVIS_COMPILER_NAME=clang
       TRAVIS_BUILD_SYSTEM=Makefile
       HYPERROGUE_USE_GLEW=1
-      HYPERROGUE_USE_PNG=1
       HYPERROGUE_USE_ROGUEVIZ=1
   - os: linux
     env: >-
@@ -92,7 +83,6 @@ matrix:
       TRAVIS_COMPILER_NAME=clang
       TRAVIS_BUILD_SYSTEM=mymake
       HYPERROGUE_USE_GLEW=1
-      HYPERROGUE_USE_PNG=1
   - os: osx
     compiler: clang
     env: >-
@@ -100,7 +90,6 @@ matrix:
       TRAVIS_COMPILER_NAME=clang
       TRAVIS_BUILD_SYSTEM=mymake
       HYPERROGUE_USE_GLEW=1
-      HYPERROGUE_USE_PNG=1
       HYPERROGUE_USE_ROGUEVIZ=1
   - os: linux
     compiler: gcc
@@ -109,7 +98,6 @@ matrix:
       TRAVIS_COMPILER_NAME=gcc
       TRAVIS_BUILD_SYSTEM=mymake
       HYPERROGUE_USE_GLEW=1
-      HYPERROGUE_USE_PNG=1
   - os: linux
     dist: bionic
     compiler: gcc
@@ -118,7 +106,6 @@ matrix:
       TRAVIS_COMPILER_NAME=gcc
       TRAVIS_BUILD_SYSTEM=mymake
       HYPERROGUE_USE_GLEW=1
-      HYPERROGUE_USE_PNG=1
       HYPERROGUE_USE_ROGUEVIZ=1
 
 before_install:
@@ -147,15 +134,13 @@ before_install:
     fi
   fi
 - |-
-  # Install libpng if asked for
-  if [[ "$HYPERROGUE_USE_PNG" == "1" ]]; then
-    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      echo 'libpng is installed by default'
-    elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      brew install libpng
-    else
-      exit 'Unsupported OS'
-    fi
+  # Install libpng
+  if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    echo 'libpng is installed by default'
+  elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    brew install libpng
+  else
+    exit 'Unsupported OS'
   fi
 - |-
   # Install autotools if asked for

--- a/Makefile.simple
+++ b/Makefile.simple
@@ -105,22 +105,14 @@ endif
 ## Begin customization points for user-specifiable HYPERROGUE_USE_XXX macros.
 
 
-hyper_OBJS = hyper$(OBJ_EXTENSION)
-hyper_LDFLAGS = $(LDFLAGS_GL) $(LDFLAGS_SDL)
+hyper_OBJS = hyper$(OBJ_EXTENSION) savepng$(OBJ_EXTENSION)
+hyper_LDFLAGS = $(LDFLAGS_GL) $(LDFLAGS_PNG) $(LDFLAGS_SDL)
 
 ifeq (${HYPERROGUE_USE_GLEW},1)
   CXXFLAGS_EARLY += -DCAP_GLEW=1
   hyper_LDFLAGS += $(LDFLAGS_GLEW)
 else
   CXXFLAGS_EARLY += -DCAP_GLEW=0
-endif
-
-ifeq (${HYPERROGUE_USE_PNG},1)
-  CXXFLAGS_EARLY += -DCAP_PNG=1
-  hyper_LDFLAGS += $(LDFLAGS_PNG)
-  hyper_OBJS += savepng$(OBJ_EXTENSION)
-else
-  CXXFLAGS_EARLY += -DCAP_PNG=0
 endif
 
 ifeq (${HYPERROGUE_USE_ROGUEVIZ},1)

--- a/screenshot.cpp
+++ b/screenshot.cpp
@@ -900,10 +900,14 @@ EX void choose_screenshot_format() {
 EX void menu() {
   cmode = sm::SIDE; 
   gamescreen(0);
-  if(format == screenshot_format::svg && !CAP_SVG) 
+#if CAP_PNG && !CAP_SVG
+  if(format == screenshot_format::svg)
     format = screenshot_format::png;
-  if(format == screenshot_format::png && !CAP_PNG) 
+#endif
+#if CAP_SVG && !CAP_PNG
+  if(format == screenshot_format::png)
     format = screenshot_format::svg;
+#endif
   dialog::init(XLAT("screenshots"), iinf[itPalace].color, 150, 100);
   dialog::addSelItem(XLAT("format"), format_name(), 'f');
   dialog::add_action_push(choose_screenshot_format);


### PR DESCRIPTION
CAP_TEXTURE now relies on CAP_PNG, and the whole thing relies on CAP_TEXTURE.
Passing `-DCAP_PNG=0` just makes the build fail.

Being tired of having my local build (on Mac OSX) fail for lack of `CAP_PNG`, I'm using this patch locally.