### PR TITLE
Remove USE_UNORDERED_MAP because it has bit-rotted.

### DIFF
--- a/asonov.cpp
+++ b/asonov.cpp
@@ -136,8 +136,8 @@ EX transmatrix adjmatrix(int i) {
   }
   
 struct hrmap_asonov : hrmap {
-  unordered_map<coord, heptagon*> at;
-    unordered_map<heptagon*, coord> coords;
+  map<coord, heptagon*> at;
+    map<heptagon*, coord> coords;
     
   heptagon *getOrigin() override { return get_at(coord(0,0,0)); }
     

--- a/basegraph.cpp
+++ b/basegraph.cpp
@@ -22,7 +22,7 @@ struct display_data {
   /** The view relative to the player character. */
   shiftmatrix player_matrix;
   /** On-screen coordinates for all the visible cells. */
-  unordered_map<cell*, shiftmatrix> cellmatrices, old_cellmatrices;
+  map<cell*, shiftmatrix> cellmatrices, old_cellmatrices;
   /** Position of the current map view, relative to the screen (0 to 1). */
   ld xmin, ymin, xmax, ymax;
   /** Position of the current map view, in pixels. */
@@ -50,7 +50,7 @@ struct display_data {
   /** Which copy of the player cell? */
   transmatrix which_copy;
   /** On-screen coordinates for all the visible cells. */
-  unordered_map<cell*, vector<shiftmatrix>> all_drawn_copies;
+  map<cell*, vector<shiftmatrix>> all_drawn_copies;
   };
 
 #define View (::hr::current_display->view_matrix)

--- a/complex.cpp
+++ b/complex.cpp
@@ -3353,7 +3353,7 @@ EX namespace ca {
   
   EX eWall wlive = waFloorA;
   
-  EX unordered_set<cell*> changed;
+  EX set<cell*> changed;
 
   EX void list_adj(cell *c) {
     changed.insert(c);

--- a/config.cpp
+++ b/config.cpp
@@ -2654,7 +2654,7 @@ EX int read_gamemode_args() {
 auto ah_config = addHook(hooks_args, 0, read_config_args) + addHook(hooks_args, 0, read_gamemode_args) + addHook(hooks_args, 0, read_color_args);
 #endif
 
-EX unordered_map<string, ld&> params = {
+EX map<string, ld&> params = {
   {"linewidth", vid.linewidth},
   {"patternlinewidth", linepatterns::width},
   {"scale", pconf.scale},

--- a/crystal.cpp
+++ b/crystal.cpp
@@ -471,7 +471,7 @@ struct hrmap_crystal : hrmap_standard {
   map<coord, heptagon*> heptagon_at;
   map<int, eLand> landmemo;
   map<coord, eLand> landmemo4;
-  unordered_map<cell*, unordered_map<cell*, int>> distmemo;
+  map<cell*, map<cell*, int>> distmemo;
   map<cell*, ldcoord> sgc;
   cell *camelot_center;
   ldcoord camelot_coord;

--- a/drawing.cpp
+++ b/drawing.cpp
@@ -2119,7 +2119,7 @@ EX void sort_drawqueue() {
   int siz = isize(ptds);
 
   #if MINIMIZE_GL_CALLS
-  unordered_map<color_t, vector<unique_ptr<drawqueueitem>>> subqueue;
+  map<color_t, vector<unique_ptr<drawqueueitem>>> subqueue;
   for(auto& p: ptds) subqueue[(p->prio == PPR::CIRCLE || p->prio == PPR::OUTCIRCLE) ? 0 : p->outline_group()].push_back(move(p));
   ptds.clear();
   for(auto& p: subqueue) for(auto& r: p.second) ptds.push_back(move(r));

--- a/euclid.cpp
+++ b/euclid.cpp
@@ -100,7 +100,7 @@ EX namespace euc {
     /** ? */  
     intmatrix inverse_axes;
     /** for canonicalization on tori */
-    unordered_map<coord, int> hash;
+    map<coord, int> hash;
     vector<coord> seq;
     int index;
 

--- a/hyper.h
+++ b/hyper.h
@@ -48,7 +48,6 @@ template<class T, class V, class... U> bool among(T x, V y, U... u) { return x==
 using std::vector;
 using std::map;
 using std::array;
-using std::unordered_map;
 using std::sort;
 using std::multimap;
 using std::set;

--- a/mapeditor.cpp
+++ b/mapeditor.cpp
@@ -1095,8 +1095,8 @@ EX namespace mapeditor {
     displayButton(8, vid.yres-8-fs*2, XLAT("ESC = return to the game"), SDLK_ESCAPE, 0);
     }
   
-  EX unordered_set<cell*> affected;
-  EX unordered_set<int> affected_id;
+  EX set<cell*> affected;
+  EX set<int> affected_id;
 
   EX void showMapEditor() {
     cmode = sm::MAP;

--- a/nonisotropic.cpp
+++ b/nonisotropic.cpp
@@ -236,8 +236,8 @@ EX namespace sn {
   struct hrmap_solnih : hrmap {
     hrmap *binary_map;
     hrmap *ternary_map; /* nih only */
-    unordered_map<pair<heptagon*, heptagon*>, heptagon*> at;
-    unordered_map<heptagon*, pair<heptagon*, heptagon*>> coords;
+    map<pair<heptagon*, heptagon*>, heptagon*> at;
+    map<heptagon*, pair<heptagon*, heptagon*>> coords;
     
     heptagon *origin;
     
@@ -872,8 +872,8 @@ EX namespace nilv {
      }
     
   struct hrmap_nil : hrmap {
-    unordered_map<mvec, heptagon*> at;
-    unordered_map<heptagon*, mvec> coords;
+    map<mvec, heptagon*> at;
+    map<heptagon*, mvec> coords;
     
     heptagon *getOrigin() override { return get_at(mvec_zero); }
     
@@ -2065,7 +2065,7 @@ EX namespace rots {
     return spin(beta) * uxpush(distance/2) * spin(-beta+alpha);
     }
   
-  std::unordered_map<int, transmatrix> saved_matrices_ray;
+  std::map<int, transmatrix> saved_matrices_ray;
 
   EX transmatrix ray_iadj(cell *c1, int i) {
     if(i == c1->type-1) return uzpush(-cgi.plevel) * spin(-2*cgi.plevel);
@@ -2097,7 +2097,7 @@ EX namespace rots {
 
   struct hrmap_rotation_space : hybrid::hrmap_hybrid {
 
-    std::unordered_map<int, transmatrix> saved_matrices;
+    std::map<int, transmatrix> saved_matrices;
 
     transmatrix adj(cell *c1, int i) override {    
       if(i == c1->type-2) return uzpush(-cgi.plevel) * spin(-2*cgi.plevel);

--- a/reg3.cpp
+++ b/reg3.cpp
@@ -601,8 +601,8 @@ EX namespace reg3 {
     hrmap *binary_map;
     hrmap_quotient3 *quotient_map;
     
-    unordered_map<heptagon*, pair<heptagon*, transmatrix>> reg_gmatrix;
-    unordered_map<heptagon*, vector<pair<heptagon*, transmatrix> > > altmap;
+    map<heptagon*, pair<heptagon*, transmatrix>> reg_gmatrix;
+    map<heptagon*, vector<pair<heptagon*, transmatrix> > > altmap;
 
     vector<cell*> spherecells;  
 
@@ -1439,7 +1439,7 @@ ld adistance(cell *c) {
   return regmap()->reg_gmatrix[c->master].first->distance * log(2) - h[0];
   }
 
-unordered_map<pair<cell*, cell*>, int> memo;
+map<pair<cell*, cell*>, int> memo;
 
 bool cdd;
 

--- a/rogueviz/janko.cpp
+++ b/rogueviz/janko.cpp
@@ -29,7 +29,7 @@ struct jmatrix : array<array<int, 7>, 7> {
   };
 
 vector<jmatrix> jms;
-std::unordered_map<jmatrix, int> ids;
+std::map<jmatrix, int> ids;
 
 jmatrix J, Z, id;
 

--- a/rogueviz/magmahep.cpp
+++ b/rogueviz/magmahep.cpp
@@ -74,7 +74,7 @@ void make() {
   for(int i=0; i<magmav; i++) vertices.push_back(vertices[i]);
   for(int i=0; i<magmav; i++) vertices.push_back(vertices[i]);
   
-  unordered_map<pair<int, int>, int> counts;
+  map<pair<int, int>, int> counts;
   
   int big = v - 2;
   

--- a/rogueviz/newconf.cpp
+++ b/rogueviz/newconf.cpp
@@ -11,7 +11,7 @@
 #endif
 
 #define main nconf_main
-#undef unordered_map
+#undef map
 #undef self
 #include "nconf.cpp"
 #undef main

--- a/rogueviz/rogueviz.cpp
+++ b/rogueviz/rogueviz.cpp
@@ -546,7 +546,7 @@ void queuedisk(const shiftmatrix& V, const colorpair& cp, bool legend, const str
     }
   }
 
-unordered_map<pair<edgeinfo*, int>, int> drawn_edges;
+map<pair<edgeinfo*, int>, int> drawn_edges;
 
 map<pair<cell*, cell*>, transmatrix> relmatrices;
 

--- a/shmup.cpp
+++ b/shmup.cpp
@@ -2527,7 +2527,7 @@ EX void turn(int delta) {
   if(doall)
     for(cell *c: currentmap->allcells()) activateMonstersAt(c);
   else
-    for(unordered_map<cell*, shiftmatrix>::iterator it = gmatrix.begin(); it != gmatrix.end(); it++) 
+    for(map<cell*, shiftmatrix>::iterator it = gmatrix.begin(); it != gmatrix.end(); it++) 
       activateMonstersAt(it->first);
   
   /* printf("size: gmatrix = %ld, active = %ld, monstersAt = %ld, delta = %d\n", 

--- a/sky.cpp
+++ b/sky.cpp
@@ -55,10 +55,7 @@ void dqi_sky::draw() {
 
   int sk = get_skybrightness();
   
-  unordered_map<cell*, pair<color_t, color_t>> colors;
-  #ifdef USE_UNORDERED_MAP
-  colors.reserve(isize(sky));
-  #endif
+  map<cell*, pair<color_t, color_t>> colors;
   for(sky_item& si: sky) colors[si.c] = 
     make_pair(darkena(gradient(0, si.color, 0, sk, 255), 0, 0xFF),
         darkena(si.skycolor, 0, 0xFF)

--- a/sysconfig.h
+++ b/sysconfig.h
@@ -487,14 +487,6 @@ typedef unsigned GLuint;
 #endif
 #endif
 
-#ifdef USE_UNORDERED_MAP
-#include <unordered_map>
-#include <unordered_set>
-#else
-#define unordered_map map
-#define unordered_set set
-#endif
-
 #include <stdint.h>
 
 #if ISWINDOWS


### PR DESCRIPTION
Trying to compile with `-DUSE_UNORDERED_MAP` produces lots of compiler errors
like these, because of missing `std::hash` specializations.
Also, `#define unordered_map map` is just evil!

```
./nonisotropic.cpp:875:36: note: in instantiation of template class 'std::__1::unordered_map<hr::nilv::mvec, hr::heptagon *,
      std::__1::hash<hr::nilv::mvec>, std::__1::equal_to<hr::nilv::mvec>, std::__1::allocator<std::__1::pair<const hr::nilv::mvec, hr::heptagon
      *> > >' requested here
    unordered_map<mvec, heptagon*> at;
                                   ^

./nonisotropic.cpp:239:58: note: in instantiation of template class 'std::__1::unordered_map<std::__1::pair<hr::heptagon *, hr::heptagon *>,
      hr::heptagon *, std::__1::hash<std::__1::pair<hr::heptagon *, hr::heptagon *> >, std::__1::equal_to<std::__1::pair<hr::heptagon *,
      hr::heptagon *> >, std::__1::allocator<std::__1::pair<const std::__1::pair<hr::heptagon *, hr::heptagon *>, hr::heptagon *> > >'
      requested here
    unordered_map<pair<heptagon*, heptagon*>, heptagon*> at;
                                                         ^

./nonisotropic.cpp:457:49: error: no matching member function for call to 'iadj'
      while(h1->distance < h2->distance) back = iadj(h2, down) * back, h2 = h2->cmove(down);
                                                ^~~~
cell.cpp:42:15: note: candidate function not viable: no known conversion from 'hr::sn::hrmap_solnih' to 'hr::hrmap' for object argument
  transmatrix iadj(heptagon *h, int d) {
              ^
cell.cpp:41:22: note: candidate function not viable: no known conversion from 'hr::sn::hrmap_solnih' to 'hr::hrmap' for object argument
  struct transmatrix iadj(cell *c, int i) { cell *c1 = c->cmove(i); return adj(c1, c->c.spin(i)); }
                     ^
```