### PR TITLE
Add "hyper.html" to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ config.log
 config.status
 configure
 depcomp
+hyper.html
 Makefile
 install-sh
 missing


### PR DESCRIPTION
`hyper.html` is created as part of the build process, and therefore shouldn't be checked in; but it seems that it was checked in anyway, in 1ac2805b7f38784cd61566d137e8e3b2a30b8a09.
If we can't stop it from being checked in, at least we can gitignore it so that it doesn't cause bogus `git diff` output.

This PR is just the silly solution to stop `git diff` from producing hundreds of lines of "hey, `make clean` deleted this file" every time you make clean.

Of course, if we _can_ stop `hyper.html` from being checked in, let's do that! 