### PR TITLE
New round of CI improvements/fixes

### DIFF
--- a/.github/workflows/github_ci.yml
+++ b/.github/workflows/github_ci.yml
@@ -77,7 +77,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: |
-        docker run --rm -v $(pwd):/src trzeci/emscripten make -f Makefile.simple emscripten
+        podman run --rm -v $(pwd):/src emscripten/emsdk make -f Makefile.simple emscripten
     - name: Do a simple test
       run: |
         ls -lAF hyper.html hyper.js hyper.wasm

--- a/.github/workflows/github_ci_logs.yml
+++ b/.github/workflows/github_ci_logs.yml
@@ -1,0 +1,32 @@
+name: Github CI log archiver
+on:
+  workflow_run:
+    workflows: ["Github CI"]
+    types:
+      - completed
+
+jobs:
+  save_logs:
+    name: Save run logs
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download log archive
+      run: |
+        curl -sI -u ${{ github.repository_owner }}:${{ github.token }} \
+          https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/logs > response.txt
+        DOWNLOAD_LINK="https:"$(cat response.txt | grep -Fi Location: | cut -d: -f3)
+        DOWNLOAD_LINK=${DOWNLOAD_LINK%$'\r'}
+        curl -JO "$DOWNLOAD_LINK"
+    - name: Unpack log archive
+      id: archive_unpack
+      run: |
+        LOG_FILENAME=$(ls logs* | cut -d. -f1)
+        echo "::set-output name=log_filename::$LOG_FILENAME"
+        7z x -ologs "$LOG_FILENAME".zip
+    - name: Upload log archive as an artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ steps.archive_unpack.outputs.log_filename }}
+        path: logs/**
+    - name: Print the link to the base run
+      run: echo "::warning::This log was saved from https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}"

--- a/.github/workflows/install_deps.sh
+++ b/.github/workflows/install_deps.sh
@@ -26,7 +26,6 @@ fi
 if [[ "$GH_OS" == "ubuntu-latest" ]]; then
   sudo apt-get -y install $GH_DEPS_UBUNTU
 elif [[ "$GH_OS" == "macos-latest" ]]; then
-  brew update
   # macos-latest already has both gcc and clang
   brew install $GH_DEPS_MACOS
   # work around https://stackoverflow.com/questions/51034399/ for now

--- a/.github/workflows/test_simple.sh
+++ b/.github/workflows/test_simple.sh
@@ -5,8 +5,7 @@ if [[ "$GH_OS" == "windows-latest" && "$GH_BUILDSYS" == "mymake" ]]; then
 
 cat << ENDOFCMDS > .github/workflows/gdb_cmds.txt
   run --version
-  backtrace
-  exit 1
+  quit 1
 ENDOFCMDS
 
   gdb --batch -x .github/workflows/gdb_cmds.txt ./hyperrogue

--- a/mymake.cpp
+++ b/mymake.cpp
@@ -57,7 +57,6 @@ void set_mingw64() {
   linker = "g++ -o hyper";
   opts = "-DWINDOWS -DCAP_GLEW=1 -DCAP_PNG=1";
   libs = " savepng.o hyper.res -lopengl32 -lSDL -lSDL_gfx -lSDL_mixer -lSDL_ttf -lpthread -lz -lglew32 -lpng";
-  setvbuf(stdout, NULL, _IONBF, 0); // MinGW is quirky with output buffering
   }
 
 vector<string> modules;
@@ -84,6 +83,7 @@ bool file_exists(string fname) {
   }
   
 int main(int argc, char **argv) {
+  setvbuf(stdout, NULL, _IONBF, 0); // this should help with responsiveness of the real-time CI logs
 #if defined(MAC)
   set_mac();
 #elif defined(WINDOWS)


### PR DESCRIPTION
Some small fixups:
- exit->quit in gdb cmdlist (funny that it sorta worked regardless)
- remove unnecessary backtrace gdb cmd (the file and line at fault are already reported without it)
- remove mymake output buffering for all platforms (should help with on-the-fly CI logs)
- remove `brew update` step (to [address](https://github.com/zenorogue/hyperrogue/pull/69#issuecomment-700277990) #69)
- move from [to-be-deprecated](https://hub.docker.com/r/trzeci/emscripten/) emscripten container

Now some stuff in need of more explanation.

Switch to `podman` instead of `docker`: this one is up to debate, but [several](https://medium.com/technopanti/docker-vs-podman-c03359fabf77) [articles](https://xperimentalhamid.com/devops/podman-vs-docker/) state that one is "better" than the other. I'll be honest and say that I'm not really sure whether all that benefits this project at all, but then again we only use `docker` in the simplest possible way.

Add a helper log-saver workflow: [addressing](https://github.com/zenorogue/hyperrogue/pull/117#issuecomment-696123813) the issue raised by @Quuxplusone in #117, this should be a temporary workaround until Github perhaps introduces a better way of doing this. For now, I had to create a helper workflow that's triggered after the main one completes, and fetches its logs using [Github's API](https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#download-workflow-run-logs), and uploads them as an artifact. It also displays a link back to the main run in the "annotations" section -- it'd be better if the main run could link to the helper workflow run instead, but there's a chicken-and-egg problem: you can only use the API query after the workflow completes, and by that point AFAIK you can't modify its "executive overview" output. [Example output](https://github.com/still-flow/hyperrogue/actions/runs/273249388). Btw, feel free to scrutinize the hell out of that one -- these rudimentary scripts were hacked together only to the point of working, not to the point of being "correct".

Note that the CI run for this PR won't produce any log archives yet, because [the corresponding `.yml` file has to exist on `master`](https://github.community/t/on-workflow-run-does-not-work-for-me/128833/2).