### PR TITLE
Avoid spurious "R'Lyeh is not what we are talking about now"

### DIFF
--- a/tour.cpp
+++ b/tour.cpp
@@ -824,7 +824,7 @@ EX slide default_slides[] = {
       QUICKFIND {
         return (l == laBurial && !items[itOrbSword]);
         };
-      SHOWLAND ( l == laCrossroads || l == laBurial );
+      SHOWLAND ( l == laRlyeh || l == laCrossroads || l == laBurial );
       }
     },
   {pcg+"Periodic patterns", 30, LEGAL::UNLIMITED | USE_SLIDE_NAME,


### PR DESCRIPTION
If you're following along with the tutorial, you'll still be in the Temple of Cthulhu when it tells you to go to the Burial Grounds. On your way there, you'll need to pass back through R'Lyeh, so we shouldn't warn you not to go there.