### PR TITLE
Update build information

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ and visualizations (see [RogueViz](http://roguetemple.com/z/hyper/rogueviz.php))
 You should be able to compile on Linux, OSX, or MinGW with something like this (you need SDL, SDL_ttf, and SDL_gfx):
 
 ```
-sudo apt-get install gcc libsdl1.2-dev libsdl-ttf2.0-dev libsdl-gfx1.2-dev
+sudo apt-get install make g++ libsdl1.2-dev libsdl-ttf2.0-dev libsdl-gfx1.2-dev libsdl-mixer1.2-dev libglew-dev
 git clone https://github.com/zenorogue/hyperrogue.git hyperrogue
 cd hyperrogue
 make
 ```
 
-The `mymake` program builds HyperRogue in parts. It takes longer than the method shown above, but when you change something, `mymake` will only recompile the changed file.
+The `mymake` program builds HyperRogue in parts. It takes longer than the method shown above, but it uses significantly less memory during compilation, and when you change something, `mymake` will only recompile the changed file.
 Additionally, it can be easily configured, e.g., to produce an optimized build, or to include addons (see `mymake.cpp` for some example invocations, and `devmods` for some example addons).
 
 ```


### PR DESCRIPTION
On Debian buster, I needed make, g++, libsdl-mixer1.2-dev, and libglew-dev to compile successfully, so add them to the list. Remove gcc from the list, since it's a dependency of g++ and so gets installed anyway. Also, mention that mymake uses less RAM to compile (relevant on RAM-constrained systems).