### PR TITLE
Teleporting to Haunted Woods no longer puts you infinitely deep

### DIFF
--- a/system.cpp
+++ b/system.cpp
@@ -183,6 +183,7 @@ EX void initgame() {
 
   if(firstland == laOceanWall) firstland = laOcean; 
   if(firstland == laHauntedWall) firstland = laGraveyard; 
+  if(firstland == laHaunted && !tactic::on) firstland = laGraveyard;
   if(firstland == laMercuryRiver) firstland = laTerracotta;
   if(firstland == laMountain && !tactic::on) firstland = laJungle;
   if(firstland == laPrincessQuest) firstland = laPalace;


### PR DESCRIPTION
Fixes #143 by making "cheat teleport" into Haunted Woods instead place you in the Graveyard with Haunted Woods generated nearby.﻿

(Sometimes this results in multiple Haunted Woods that collide and look a bit weird, but I'm guessing that's okay.)