### PR TITLE
Orb of Change no longer produces Jiangshi or Desert Man

### DIFF
--- a/orbs.cpp
+++ b/orbs.cpp
@@ -1039,10 +1039,10 @@ void poly_attack(cell *dest) {
   eMonster orig = dest->monst;
   auto polymonsters = {
     moYeti, moRunDog, moRanger,
-    moDesertman, moMonkey, moCultist,
+    moMonkey, moCultist,
     moFallingDog, moVariantWarrior, moFamiliar, moOrangeDog,
     moRedFox, moFalsePrincess, moResearcher,
-    moNarciss, moJiangshi, 
+    moNarciss,
     };
   int ssf = 0;
   eMonster target = *(polymonsters.begin() + hrand(isize(polymonsters)));


### PR DESCRIPTION
The Orb of Change is supposed to only create monsters with no special properties. Jiangshi are non-living (do not wake terracotta statues); Desert Men produce heat in cold lands.