### PR TITLE
Fix extra Viziers when walking around the Palace with 12 treasures

### DIFF
--- a/items.cpp
+++ b/items.cpp
@@ -106,7 +106,7 @@ EX bool collectItem(cell *c2, bool telekinesis IS(false)) {
     string s0 = "";
     
     if(c2->item == itPalace && items[c2->item] == 12)
-      princess::forceVizier = true;
+      changes.value_set(princess::forceVizier, true);
     
     if(!cantGetGrimoire(c2, false)) collectMessage(c2, c2->item);
     if(c2->item == itDodeca && peace::on) peace::simon::extend();


### PR DESCRIPTION
Fix a bug where walking next to (but not collecting) a 13th Hypersian Rug causes a Vizier to spawn. With this fix, the vizier only appears upon actually collecting the 13th Hypersian Rug, and therefore only one extra Vizier appears per game.