### PR TITLE
Orb of Luck no longer appears in Free Fall

### DIFF
--- a/orbgen.cpp
+++ b/orbgen.cpp
@@ -276,6 +276,8 @@ EX eOrbLandRelation getOLR(eItem it, eLand l) {
     return olrUseless;
   if(it == itOrbLuck && l == laMountain)
     return olrUseless;
+  if(it == itOrbLuck && l == laWestWall)
+    return olrUseless;
    if(it == itOrbLuck && l == laCamelot)
     return olrUseless;
    if(it == itOrbLuck && l == laHaunted)


### PR DESCRIPTION
Free Fall does not generate new great walls, so Orb of Luck is useless in Free Fall﻿
