### PR TITLE
Orb of Friendship no longer appears in Terracotta Army

### DIFF
--- a/orbgen.cpp
+++ b/orbgen.cpp
@@ -394,6 +394,9 @@ EX eOrbLandRelation getOLR(eItem it, eLand l) {
       it == itOrbAether || it == itOrbSummon || it == itOrbStone) 
       return olrForbidden;
     }
+
+  if(l == laTerracotta && it == itOrbFriend)
+    return olrDangerous;
   
   return olrPrize25;
   }


### PR DESCRIPTION
Friendly Bomberbirds tend to wake up Terracotta Statues, making it dangerous to summon the birds here﻿