### PR TITLE
[DRAFT] An approach to linting the translations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ hyper$(OBJ_EXTENSION): *.cpp language-data.cpp autohdr.h
 hyper.res: hyper.rc hr-icon.ico
 	windres hyper.rc -O coff -o hyper.res
 
-langen$(EXE_EXTENSION): langen.cpp language-??.cpp language-ptbr.cpp
+langen$(EXE_EXTENSION): langen.cpp language-??.cpp language-ptbr.cpp all-string-literals.ipp
 	$(CXX) -O0 $(CXXFLAGS) $(langen_CXXFLAGS) langen.cpp $(LDFLAGS) -o $@
 
 makeh$(EXE_EXTENSION): makeh.cpp
@@ -154,6 +154,9 @@ makeh$(EXE_EXTENSION): makeh.cpp
 
 autohdr.h: makeh$(EXE_EXTENSION) language-data.cpp *.cpp
 	./makeh classes.cpp locations.cpp colors.cpp hyperpoint.cpp geometry.cpp goldberg.cpp init.cpp floorshapes.cpp cell.cpp multi.cpp shmup.cpp pattern2.cpp mapeditor.cpp graph.cpp textures.cpp hprint.cpp language.cpp util.cpp complex.cpp *.cpp > autohdr.h
+
+all-string-literals.ipp: lanlint.py *.cpp
+	python lanlint.py > all-string-literals.ipp
 
 language-data.cpp: langen$(EXE_EXTENSION)
 	./langen > language-data.cpp
@@ -179,3 +182,4 @@ clean:
 	rm -rf mymake$(EXE_EXTENSION) mymake_files/
 	rm -f hyperrogue$(EXE_EXTENSION) hyper$(OBJ_EXTENSION) $(hyper_RES) savepng$(OBJ_EXTENSION)
 	rm -f hyper.html hyper.js hyper.wasm
+	rm -f all-string-literals.ipp

--- a/lanlint.py
+++ b/lanlint.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+import glob
+
+def get_file_strings(fname):
+    result = []
+    with open(fname, "r") as f:
+        text = f.read()
+    i = 0
+    start = None
+    current_string = None
+    while i < len(text):
+        if (start is None) and (text[i:i+2] == '//'):
+            while text[i] != '\n':
+                i += 1
+        elif (start is None) and (text[i] == '"'):
+            if (text[i-1] == 'R'):
+                i += 1
+                while text[i] != '"': i += 1
+            else:
+                start = i
+        elif (start is None) and (text[i] in ' \t\n'):
+            pass
+        elif (start is None) and (text[i:i+3] == "'\"'"):
+            i += 2  # skip over character literals that might otherwise confuse us
+        elif (start is None):
+            if current_string:
+                result += [current_string]
+                # print(current_string)
+                # print("---------------------")
+            current_string = ''
+        elif (start is not None) and (text[i] == '\\'):
+            i += 1
+        elif (start is not None) and (text[i] == '"'):
+            current_string += text[start:i+1]
+            start = None
+        else:
+            pass  # just a plain old string character
+        i += 1
+    if current_string:
+        result += [current_string]
+    return result
+
+def get_program_strings():
+    result = []
+    for fname in glob.glob("*.cpp"):
+        if not fname.startswith("language-"):
+            result += get_file_strings(fname)
+    return result
+
+if __name__ == '__main__':
+    program_strings = set(get_program_strings())
+    print('const char *program_strings[] = {')
+    for s in program_strings:
+        print('    %s,' % s)
+    print('};')


### PR DESCRIPTION
As noted in #154, it's very easy to "break" the translations files. If we wanted, we could try to automate the detection of broken translations, by comparing the strings in `language-??.cpp` against the strings in the actual program source code. I wrote a little proof-of-concept, using a Python script to extract the string literals from the program. Run `make` to see the very spammy output:
```
Unused translation in PL,CZ,RU,DE: "\n\nOnce you collect 10 Bomberbird Eggs, stepping on a cell with no adjacent mines also reveals the adjacent cells. Collecting even more Eggs will increase the radius. Additionally, collecting 25 Bomberbird Eggs will reveal adjacent cells even in your future games."
Closest match in program: "\n\nOnce you collect a Bomberbird Egg, stepping on a cell with no adjacent mines also reveals the adjacent cells. Collecting even more Eggs will increase the radius."
Unused translation in PL,CZ,RU,TR,DE: " (E:%1)"
Closest match in program: " (e)"
Unused translation in PL,CZ,RU,TR,DE,PT: " (expired)"
Closest match in program: " (Emerald)"
Unused translation in PL,CZ,RU: " (increases treasure spawn)"
Closest match in program: " (killing increases treasure spawn)"
Unused translation in DE: " Hell: %1/9"
Closest match in program: " Hell: %1/%2"
Unused translation in PL,CZ,RU,TR,DE,PT: " [%1 turns]"
Closest match in program: "%1 turns"
Unused translation in PL,CZ,RU,TR,DE: " kills: %1"
Closest match in program: "kills: %1"
Unused translation in PL,CZ,RU,TR,DE: "\"By now, you should have your own formula, you know?\""
Closest match in program: "\"I would like to congratulate you again!\""
Unused translation in PL,CZ,RU,TR,DE: "\"I like collecting ambers at the beach.\""
Closest match in program: "finer lines at the boundary"
Unused translation in PL,CZ: "#%1, cells: %2"
Closest match in program: "bad cells: %1"
Unused translation in PL,CZ,RU,TR,DE: "%1 takes %his1 revenge on %the2!"
Closest match in program: "%The1 takes %his1 revenge on %the2!"
Unused translation in PL,CZ,RU,TR,DE: "%The1 bites %the2!"
Closest match in program: "%The1 eats %the2!"
Unused translation in PL,CZ,RU,TR,DE,PT: "%The1 breaks the mirror!"
Closest match in program: "%The1 breathes fire!"
Unused translation in PL,CZ,RU,TR,DE,PT: "%The1 disperses the cloud!"
Closest match in program: "%The1 fills the hole!"
[...and so on, and so on ... 674 lines...]
```

I don't expect this to be merged as-is. But it might serve as a jumping-off point for someone either to polish this automated detector, _or_ to go through its spammy output and make a pull request fixing the low-hanging fruit. E.g. changing `"%1 takes %his1 revenge on %the2!"` into `"%The1 takes %his1 revenge on %the2!"`