### PR TITLE
Fix typo in Jelly Kingdom description

### DIFF
--- a/classes.cpp
+++ b/classes.cpp
@@ -411,7 +411,7 @@ const char *twdesc = "This structure will disappear after some time.";
 const char *jellydesc = 
   "Some of the Slime Beasts have decided to revolt against the color rules in the "
   "Alchemist Lab. They have changed their shape and consistency, declared independence, and established their own Kingdom.\n\n"
-  "Jellies switch between being a wall and being a monster after every treasure you pick.";
+  "Jellies switch between being a wall and being a monster after every treasure you collect.";
 
 const char *ruindesc = 
   "Once a beautiful city... but now overrun by the mighty Raiders of unknown origin.\n\n"

--- a/language-cz.cpp
+++ b/language-cz.cpp
@@ -6727,7 +6727,7 @@ N("Jelly Kingdom", GEN_N, "Království rosolu", "Království rosolu", "Králov
 
 S("Some of the Slime Beasts have decided to revolt against the color rules in the "
   "Alchemist Lab. They have changed their shape and consistency, declared independence, and established their own Kingdom.\n\n"
-  "Jellies switch between being a wall and being a monster after every treasure you pick.",
+  "Jellies switch between being a wall and being a monster after every treasure you collect.",
   
   "Nìkteøí Slizoví netvoøi se rozhodli vzbouøit proti barevným pravidlùm v Alchymistické laboratoøi. Zmìnili svùj tvar a konzistencim vyhlásili nezávislost a založili si své vlastní Království.\n\n"
   "Kdykoli sebereš nìjaký poklad, rosoly se zmìní ze zdí na netvory a opaènì."

--- a/language-pl.cpp
+++ b/language-pl.cpp
@@ -6566,7 +6566,7 @@ N("Jelly Kingdom", GEN_N, "Królestwo Galarety", "Królestwa Galarety", "Króles
 
 S("Some of the Slime Beasts have decided to revolt against the color rules in the "
   "Alchemist Lab. They have changed their shape and consistency, declared independence, and established their own Kingdom.\n\n"
-  "Jellies switch between being a wall and being a monster after every treasure you pick.",
+  "Jellies switch between being a wall and being a monster after every treasure you collect.",
   
   "Część Mazistych Stworów z Laboratorium postanowiło zbuntować się przeciwko regułom koloru w "
   "Laboratorium. Zmieniły kształt i konsystencję, ogłosiły niepodległość i stworzyły własne Królestwo.\n\n"

--- a/language-ru.cpp
+++ b/language-ru.cpp
@@ -6793,7 +6793,7 @@ N("Jelly Kingdom", GEN_N, "Желейное Королевство", "Желей
  
 S("Some of the Slime Beasts have decided to revolt against the color rules in the "
   "Alchemist Lab. They have changed their shape and consistency, declared independence, and established their own Kingdom.\n\n"
-  "Jellies switch between being a wall and being a monster after every treasure you pick.",
+  "Jellies switch between being a wall and being a monster after every treasure you collect.",
  
   "Часть Живой Слизи выступила против правил цветов в Лаборатории. "
   "Они изменили свою форму и густоту, провозгласили независимость и образовали свое Королевство.\n\n"


### PR DESCRIPTION
Changing the incomplete "every treasure you _pick_" to "every treasure you _collect_".

I chose "collect" rather than "pick up" for consistency with other text in the game. I updated the English text in translation files because I don't think this requires re-translation.