### PR TITLE
Fix typo in Free Fall description

### DIFF
--- a/content.cpp
+++ b/content.cpp
@@ -1523,7 +1523,7 @@ LAND( 0x804000, "Brown Island", laBrownian, ZERO | LF_PURESEA, itBrownian, RESER
   REQAS(laOcean,)
 
 LAND( 0x211F6F, "Free Fall", laWestWall, ZERO | LF_GRAVITY | LF_EQUI, itWest, RESERVED, 
-    "What on one side looks to be a normal (well, infinite) horizontal wall, on to the other side turns out to be the vertical wall"
+    "What on one side looks to be a normal (well, infinite) horizontal wall, on the other side turns out to be the vertical wall"
     " of an infinitely high tower. Jump from the window, and let the magical gravity carry you..."
     )
   NATIVE(among(m, moWestHawk, moFallingDog) ? 2 : 0)

--- a/language-cz.cpp
+++ b/language-cz.cpp
@@ -7700,7 +7700,7 @@ S("Did you know that it is possible to break a magical sphere into finitely many
     
 N("Free Fall", GEN_O, "Volný pád", "Volné pády", "Volný pád", "ve Volném pádu")
 
-S("What on one side looks to be a normal (well, infinite) horizontal wall, on to the other side turns out to be the vertical wall"
+S("What on one side looks to be a normal (well, infinite) horizontal wall, on the other side turns out to be the vertical wall"
   " of an infinitely high tower. Jump from the window, and let the magical gravity carry you...",
 
   "To, co na jedné straně vypadá jako normální (no, nekonečná) vodorovná "

--- a/language-pl.cpp
+++ b/language-pl.cpp
@@ -7443,7 +7443,7 @@ S("Did you know that it is possible to break a magical sphere into finitely many
     
 N("Free Fall", GEN_O, "Swobodny Spadek", "Swobodne Spadki", "Swobodny Spadek", "w Swobodnym Spadku")
 
-S("What on one side looks to be a normal (well, infinite) horizontal wall, on to the other side turns out to be the vertical wall"
+S("What on one side looks to be a normal (well, infinite) horizontal wall, on the other side turns out to be the vertical wall"
   " of an infinitely high tower. Jump from the window, and let the magical gravity carry you...",
 
   "Co wygląda z jednej strony na zwykłą (nieskończoną) poziomą ścianę, z drugiej strony okazuje się być pionową ścianą nieskończenie "


### PR DESCRIPTION
"on _to_ the other side" -> "on the other side"

And changing the English string in the translation files, because I don't think this change requires re-translation.