### PR TITLE
Remove extra semis in struct defs

### DIFF
--- a/cell.cpp
+++ b/cell.cpp
@@ -16,7 +16,7 @@ extern int default_levs();
 struct hrmap {
   virtual heptagon *getOrigin() { return NULL; }
   virtual cell *gamestart() { return getOrigin()->c7; }
-  virtual ~hrmap() { };
+  virtual ~hrmap() { }
   virtual vector<cell*>& allcells();
   virtual void verify() { }
   virtual void on_dim_change() { }

--- a/config.cpp
+++ b/config.cpp
@@ -27,7 +27,7 @@ struct supersaver {
   virtual void load(const string& s) = 0;
   virtual bool dosave() = 0;
   virtual void reset() = 0;
-  virtual ~supersaver() {};
+  virtual ~supersaver() {}
   virtual bool affects(void* v) { return false; }
   virtual void set_default() = 0;
   };

--- a/earcut.hpp
+++ b/earcut.hpp
@@ -30,7 +30,7 @@ namespace util {
 
 template <std::size_t I, typename T> struct nth {
     inline static typename std::tuple_element<I, T>::type
-    get(const T& t) { return std::get<I>(t); };
+    get(const T& t) { return std::get<I>(t); }
 };
 
 }

--- a/hyper.h
+++ b/hyper.h
@@ -26,8 +26,8 @@ namespace hr {
 
 /** \brief A helper structure that acts as a boolean which is always false. Helpful when disabling stuff with compiler flags. */
 struct always_false {
-  operator bool() const { return false; };
-  bool operator = (bool b) const { return b; };
+  operator bool() const { return false; }
+  bool operator = (bool b) const { return b; }
   };
 
 /** \brief placate GCC's overzealous -Wunused-result */


### PR DESCRIPTION
These were found using clang's -Wextra-semi﻿
