### PR TITLE
Remove unused catch binding

### DIFF
--- a/pattern2.cpp
+++ b/pattern2.cpp
@@ -1744,7 +1744,7 @@ EX namespace patterns {
     try {
       return ep.parse();
       }
-    catch(hr_parse_exception& ex) {
+    catch(hr_parse_exception&) {
       return 0;
       }
     }


### PR DESCRIPTION
If I enable -Wunused-exception-parameter, this instance is the only warning I get when compiling HyperRogue.﻿
