### PR TITLE
Orb of the Dragon can no longer target underwater items

### DIFF
--- a/mapeffects.cpp
+++ b/mapeffects.cpp
@@ -355,12 +355,12 @@ EX bool snakepile(cell *c, eMonster m) {
 EX bool makeflame(cell *c, int timeout, bool checkonly) {
   changes.ccell(c);
   if(!checkonly) destroyTrapsOn(c);
-  if(itemBurns(c->item)) {
-    if(checkonly) return true;
+  if(!checkonly && itemBurns(c->item)) {
     if(c->cpdist <= 7)
       addMessage(XLAT("%The1 burns!", c->item));
     c->item = itNone;
     }
+
   if(cellUnstable(c)) {
     if(checkonly) return true;
     doesFall(c);


### PR DESCRIPTION
This fixes a gameplay exploit where shift+hovering with Orb of the Dragon revealed which sea cells contain hidden items.﻿