### PR TITLE
Orb of Time now preserves Orb of Plague properly

### DIFF
--- a/pcmove.cpp
+++ b/pcmove.cpp
@@ -1497,7 +1497,8 @@ EX void swordAttackStatic() {
 EX int plague_kills;
 
 EX void spread_plague(cell *mf, cell *mt, int dir, eMonster who) {
-  if(!(who == moPlayer ? markOrb(itOrbPlague) : markEmpathy(itOrbPlague))) return;
+  if(!items[itOrbPlague]) return;
+  if(who != moPlayer && !items[itOrbEmpathy]) return;
   forCellEx(mx, mt) if(celldistance(mx, mf) > celldistance(mx, mf->modmove(dir)) && celldistance(mx, mf) <= 4) {
     sideAttackAt(mf, dir, mx, who, itOrbPlague, mt);
     }


### PR DESCRIPTION
Before this change: with the Orb of Time and Orb of Plague both active, every attack would deplete Orb of Plague

After this change: with the Orb of Time and Orb of Plague both active, attacks only deplete the Orb of Plague when they actually spread

Why this change works: sideAttackAt handles calling markOrb