### PR TITLE
Overview cheats: arrow keys no longer make treasure/orb counts negative

### DIFF
--- a/menus.cpp
+++ b/menus.cpp
@@ -186,6 +186,7 @@ EX void showOverview() {
           else checkmove();
           cheater++;
           };
+        dialog::bound_low(0);
         }
       }
     else if(udiv == 3 && umod < walltypes) gotoHelp(generateHelpForWall(eWall(umod)));


### PR DESCRIPTION
With this change, holding the left arrow key stops at 0 instead of going into negative territory.