### PR TITLE
Resolve conflict between 'Galápagos shading' and 'teleport'

### DIFF
--- a/help.cpp
+++ b/help.cpp
@@ -1179,7 +1179,7 @@ EX void gotoHelpFor(eLand l) {
   else listbeasts();  
   
   if(l == laTortoise)
-    help_extensions.push_back(help_extension{'t', XLAT("Galápagos shading"), [] () {
+    help_extensions.push_back(help_extension{'s', XLAT("Galápagos shading"), [] () {
       tortoise::shading_enabled = !tortoise::shading_enabled;
       }});
   }


### PR DESCRIPTION
When accessing Galápagos from the overview with cheat mode enabled, 'Galápagos shading' and 'teleport' need different keys in order for 'teleport' to be clickable.