### PR TITLE
Fix HUD kill list in 'items only' mode

### DIFF
--- a/hud.cpp
+++ b/hud.cpp
@@ -173,10 +173,10 @@ int glyphflags(int gid) {
   return f;
   }
 
-EX bool graphglyph() {
+EX bool graphglyph(bool isMonster) {
   // if(GDIM == 3) return false;
   if(vrhr::active()) return false;
-  return vid.graphglyph == 2 || (vid.graphglyph == 1 && vid.monmode);
+  return vid.graphglyph == 2 || (vid.graphglyph == 1 && (isMonster ? mmmon : mmitem));
   }
 
 bool displayglyph(int cx, int cy, int buttonsize, char glyph, color_t color, int qty, int flags, int id) {
@@ -190,10 +190,11 @@ bool displayglyph(int cx, int cy, int buttonsize, char glyph, color_t color, int
   int d = ticks - glasttime[id];
   double zoom = (d <= 250 && d >= 0) ? 1.25 - .001 * d : 1;
   glsize = int(glsize * zoom);
+  bool isMonster = (id >= ittypes);
   
-  if(graphglyph()) {
+  if(graphglyph(isMonster)) {
     initquickqueue();
-    if(id >= ittypes) {
+    if(isMonster) {
       eMonster m = eMonster(id - ittypes);
       double bsize = buttonsize * 2/3;
       if(m == moKrakenH) bsize /= 3;

--- a/inventory.cpp
+++ b/inventory.cpp
@@ -534,7 +534,7 @@ EX namespace inv {
             ld py = current_display->ycenter + pos.second * rad3;
             int icol = iinf[o].color;
             if(!remaining[i]) icol = gradient(icol, 0, 0, .5, 1);
-            bool gg = graphglyph();
+            bool gg = graphglyph(false);
             
             if(!hiliteclick) {
               if(gg) {


### PR DESCRIPTION
Previously, setting 'monster display mode' to 'items only' (i.e. ASCII monsters but graphical items) would make HUD kill list items disappaer.﻿
