### PR TITLE
Dice can now be pushed onto items

### DIFF
--- a/game.cpp
+++ b/game.cpp
@@ -430,7 +430,7 @@ EX bool canPushThumperOn(movei mi, cell *player) {
   return
     passable(tgt, thumper, P_MIRROR) &&
     passable(tgt, player, P_MIRROR) &&
-    !tgt->item;
+    (!tgt->item || dice::on(thumper));
   }
 
 EX void activateActiv(cell *c, bool msg) {


### PR DESCRIPTION
Dice can be blown onto items, and can roll onto items themselves, so it should be possible to push them onto items too.