### PR TITLE
Filtering the Overview now hides page buttons reliably

### DIFF
--- a/menus.cpp
+++ b/menus.cpp
@@ -41,7 +41,7 @@ EX void showOverview() {
       mouseovers += XLAT(" Hell: %1/%2", its(orbsUnlocked()), its(lands_for_hell()));
     }
   
-  bool pages;
+  bool pages = false;
   
   {
   dynamicval<int> ds(dual::state, dual::state ? 2 : 0);


### PR DESCRIPTION
Fixes UBSan complaint when filtering the overview:

```
menus.cpp:150:33: runtime error: load of value 22, which is not a valid value for type 'bool'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior menus.cpp:150:33 in
```