### PR TITLE
Fix crash after using Orb of Domination

### DIFF
--- a/complex.cpp
+++ b/complex.cpp
@@ -2597,7 +2597,7 @@ EX }
 EX namespace dragon {
  
   EX int whichturn; // which turn has the target been set on
-  EX cell *target; // actually for all Orb of Control
+  EX cell *target; // actually for all Orb of Domination
 
   void pullback(cell *c) {
     int maxlen = iteration_limit;
@@ -3467,6 +3467,7 @@ auto ccm = addHook(hooks_clearmemory, 0, [] () {
   clearing::score.clear();
   tortoise::emap.clear();
   tortoise::babymap.clear();
+  dragon::target = NULL;
   #if CAP_FIELD
   prairie::lasttreasure = NULL;
   prairie::enter = NULL;
@@ -3510,6 +3511,7 @@ auto ccm = addHook(hooks_clearmemory, 0, [] () {
         }
       return false; 
       });
+    set_if_removed(dragon::target, NULL);
     #if CAP_FIELD
     set_if_removed(prairie::lasttreasure, NULL);
     set_if_removed(prairie::enter, NULL);


### PR DESCRIPTION
HyperRogue could crash after targeting the Orb of Domination (making dragon::target point to a cell), then using Safety (deleting the cell), then being on the same cell as a monster (causing dragon::target to be dereferenced due to MF_MOUNT).

This PR clears dragon::target when the cell is deleted. I believe this change is necessary and sufficient to prevent the crash, although there may be additional spots where it makes sense to clear dragon::target.

I will also submit changes in other PRs so dragon::target is used less often (by making it less likely for the player to share a cell with monsters, and by only setting MF_MOUNT when on a worm-type monster).