### PR TITLE
Cave transformation is fairer to players

### DIFF
--- a/attack.cpp
+++ b/attack.cpp
@@ -567,7 +567,8 @@ EX void killMonster(cell *c, eMonster who, flagtype deathflags IS(0)) {
     forCellEx(c1, c) {
       changes.ccell(c1);
       c1->item = itNone;
-      if(c1->wall == waDeadwall || c1->wall == waDeadfloor2) c1->wall = waCavewall;
+      if(c1->wall == waDeadwall) c1->wall = waCavewall;
+      if(c1->wall == waDeadfloor2 && !c1->monst && !isPlayerOn(c1)) c1->wall = waCavewall;
       if(c1->wall == waDeadfloor) c1->wall = waCavefloor;
       }
     }

--- a/complex.cpp
+++ b/complex.cpp
@@ -2349,7 +2349,7 @@ EX void livecaves() {
       for(cell *c2: adj_minefield_cells(c)) {
         eWall w = c2->wall;
         if(w == waDeadfloor) hv++, bringlife.push_back(c2);
-        else if(w == waDeadwall || (w == waDeadfloor2 && !c2->monst))
+        else if(w == waDeadwall || (w == waDeadfloor2 && !c2->monst && !isPlayerOn(c2)))
           hv--, bringlife.push_back(c2);
         else if(w == waCavefloor) hv++;
         else if(w == waCavewall) hv--;


### PR DESCRIPTION
Cave walls will no longer grow on the player's cell (both in the initial splash around the rock troll, and in the CA updates). Instead, the cell remains rubble, waiting to spring a wall when you move off of it.﻿
