### PR TITLE
Reversing the Curse of Water now gives bonus Orb of Winter

### DIFF
--- a/orbs.cpp
+++ b/orbs.cpp
@@ -115,7 +115,7 @@ EX void reduceOrbPowerAlways(eItem it) {
 EX void reverse_curse(eItem curse, eItem orb, bool cancel) {
   if(items[curse] && markOrb(itOrbPurity)) {
     items[orb] += items[curse];
-    if(curse == itCurseWeakness) items[itOrbWinter] += items[curse];
+    if(curse == itCurseWater) items[itOrbWinter] += items[curse];
     items[curse] = 0;
     }
   if(cancel && items[curse] && items[orb]) {


### PR DESCRIPTION
I think this line was intended to give Orb of Winter upon reversing the Curse of Water, in order to complement the Orb of Fire and avoid trapping the player with fire.
