### PR TITLE
Fix crash when an unknown princess is in peril

### DIFF
--- a/attack.cpp
+++ b/attack.cpp
@@ -512,8 +512,8 @@ EX void killMonster(cell *c, eMonster who, flagtype deathflags IS(0)) {
   
   if(m == moPrincess) {
     princess::info *i = princess::getPrincessInfo(c);
-    changes.value_keep(*i);
     if(i) {
+      changes.value_keep(*i);
       i->princess = NULL;
       if(i->bestdist == OUT_OF_PALACE) {
         items[itSavedPrincess]--;


### PR DESCRIPTION
This fixes a crash when doing the following:

1. Use the map editor to summon an unarmed princess on a cell adjacent to the player
2. Use the orb of thorns to kill the princess over several moves﻿
