### PR TITLE
Fix crash by disallowing statue-dice swaps

### DIFF
--- a/passable.cpp
+++ b/passable.cpp
@@ -409,7 +409,7 @@ bool sharkpassable(cell *w, cell *c) {
 EX bool canPushStatueOn(cell *c, flagtype flags) {
   return passable(c, NULL, P_MONSTER | flags) && !snakelevel(c) &&
     !isWorm(c->monst) && !isReptile(c->wall) && !peace::on && 
-    !cellHalfvine(c) &&
+    !cellHalfvine(c) && !isDie(c->wall) &&
     !among(c->wall, waBoat, waFireTrap, waArrowTrap);
   }
 


### PR DESCRIPTION
Disallow swaps between (happy/unhappy dice) and (big statues of cthulhu), because that would move the dice in a way that does not update dice::data correctly.

Note: it is difficult to enter happy dice; one way is aether+teleport.
