### PR TITLE
Fix array indexing in totalbulldistance

### DIFF
--- a/monstermove.cpp
+++ b/monstermove.cpp
@@ -567,7 +567,7 @@ EX int totalbulldistance(cell *c, int k) {
   shpos.resize(SHSIZE);
   int tbd = 0;
   for(int p: player_indices()) {
-    cell *c2  = shpos[p][(cshpos+SHSIZE-k-1)%SHSIZE];
+    cell *c2  = shpos[(cshpos+SHSIZE-k-1)%SHSIZE][p];
     if(c2) tbd += bulldistance(c, c2);
     }
   return tbd;


### PR DESCRIPTION
shpos is a vector of size SHSIZE=16, containing arrays of size MAXPLAYER=7. Mixing up the indexes resulted in out-of-bounds accesses to the inner array (caught by UBSan).
