### PR TITLE
Fix or suppress a bunch of Clang warnings. NFCI.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ ifeq (${TOOLCHAIN},clang)
   CXXFLAGS_STD = -std=c++11
   CXXFLAGS_EARLY += -march=native -fPIC
   CXXFLAGS_EARLY += -W -Wall -Wextra -Werror -pedantic
-  CXXFLAGS_EARLY += -Wno-unused-parameter -Wno-implicit-fallthrough -Wno-maybe-uninitialized -Wno-unknown-warning-option
+  CXXFLAGS_EARLY += -Wno-unused-parameter -Wno-implicit-fallthrough -Wno-maybe-uninitialized -Wno-unknown-warning-option -Wno-overloaded-virtual
 endif
 
 ifeq (${TOOLCHAIN},gcc)

--- a/drawing.cpp
+++ b/drawing.cpp
@@ -56,7 +56,7 @@ struct drawqueueitem {
   virtual void draw() = 0;
   /** \brief Draw the object as background. */
   virtual void draw_back() {}
-  virtual ~drawqueueitem() {}
+  virtual ~drawqueueitem() = default;
   /** \brief When minimizing OpenGL calls, we need to group items of the same color, etc. together. This value is used as an extra sorting key. */
   virtual color_t outline_group() = 0;
   };
@@ -85,12 +85,12 @@ struct dqi_poly : drawqueueitem {
   hyperpoint intester;
   /** \brief temporarily cached data */
   float cache;
-  void draw();
+  void draw() override;
   #if CAP_GL
   void gldraw();
   #endif
-  void draw_back();
-  virtual color_t outline_group() { return outline; }
+  void draw_back() override;
+  color_t outline_group() override { return outline; }
   };
 
 /** \brief Drawqueueitem used to draw lines */
@@ -101,9 +101,9 @@ struct dqi_line : drawqueueitem {
   int prf;
   /** \brief width of this line */
   double width;
-  void draw();
-  void draw_back();
-  virtual color_t outline_group() { return color; }
+  void draw() override;
+  void draw_back() override;
+  color_t outline_group() override { return color; }
   };
 
 /** \brief Drawqueueitem used to draw strings, using sccreen coodinates */      
@@ -120,8 +120,8 @@ struct dqi_string : drawqueueitem {
   int frame;
   /** alignment (0-8-16) */
   int align;
-  void draw();
-  virtual color_t outline_group() { return 1; }
+  void draw() override;
+  color_t outline_group() override { return 1; }
   };
 
 /** Drawqueueitem used to draw circles, using screen coordinates */
@@ -134,16 +134,16 @@ struct dqi_circle : drawqueueitem {
   color_t fillcolor;
   /** \brief width of the circle */
   double linewidth;
-  void draw();
-  virtual color_t outline_group() { return 2; }
+  void draw() override;
+  color_t outline_group() override { return 2; }
   };
 
 /** \brief Perform an arbitrary action. May temporarily change the model, etc. */
 struct dqi_action : drawqueueitem {
   reaction_t action;
-  dqi_action(const reaction_t& a) : action(a) {}
-  void draw() { action(); }
-  virtual color_t outline_group() { return 2; }
+  explicit dqi_action(const reaction_t& a) : action(a) {}
+  void draw() override { action(); }
+  color_t outline_group() override { return 2; }
   };
 #endif
 

--- a/hprint.cpp
+++ b/hprint.cpp
@@ -122,25 +122,25 @@ struct hstream_exception : hr_exception { hstream_exception() {} };
 
 struct fhstream : hstream {
   color_t vernum;
-  virtual color_t get_vernum() override { return vernum; }
   FILE *f;
-  virtual void write_char(char c) override { write_chars(&c, 1); }
-  virtual void write_chars(const char* c, size_t i) override { if(fwrite(c, i, 1, f) != 1) throw hstream_exception(); }
-  virtual void read_chars(char* c, size_t i) override { if(fread(c, i, 1, f) != 1) throw hstream_exception(); }
-  virtual char read_char() override { char c; read_chars(&c, 1); return c; }
-  fhstream() { f = NULL; vernum = VERNUM_HEX; }
-  fhstream(const string pathname, const char *mode) { f = fopen(pathname.c_str(), mode); vernum = VERNUM_HEX; }
+  explicit fhstream() { f = NULL; vernum = VERNUM_HEX; }
+  explicit fhstream(const string pathname, const char *mode) { f = fopen(pathname.c_str(), mode); vernum = VERNUM_HEX; }
   ~fhstream() { if(f) fclose(f); }
+  color_t get_vernum() override { return vernum; }
+  void write_char(char c) override { write_chars(&c, 1); }
+  void write_chars(const char* c, size_t i) override { if(fwrite(c, i, 1, f) != 1) throw hstream_exception(); }
+  void read_chars(char* c, size_t i) override { if(fread(c, i, 1, f) != 1) throw hstream_exception(); }
+  char read_char() override { char c; read_chars(&c, 1); return c; }
   };
 
 struct shstream : hstream { 
   color_t vernum;
-  virtual color_t get_vernum() override { return vernum; }
   string s;
   int pos;
-  shstream(const string& t = "") : s(t) { pos = 0; vernum = VERNUM_HEX; }
-  virtual void write_char(char c) override { s += c; }
-  virtual char read_char() override { if(pos == isize(s)) throw hstream_exception(); return s[pos++]; }
+  explicit shstream(const string& t = "") : s(t) { pos = 0; vernum = VERNUM_HEX; }
+  color_t get_vernum() override { return vernum; }
+  void write_char(char c) override { s += c; }
+  char read_char() override { if(pos == isize(s)) throw hstream_exception(); return s[pos++]; }
   };
 
 inline void print(hstream& hs) {}
@@ -243,11 +243,11 @@ int SDL_GetTicks();
 struct logger : hstream {
   int indentation;
   bool doindent;
-  logger() { doindent = false; }
-  virtual void write_char(char c) { if(doindent) { doindent = false; 
+  explicit logger() { doindent = false; }
+  void write_char(char c) override { if(doindent) { doindent = false; 
     if(debugflags & DF_TIME) { int t = SDL_GetTicks(); if(t < 0) t = 999999; t %= 1000000; string s = its(t); while(isize(s) < 6) s = "0" + s; for(char c: s) special_log(c); special_log(' '); }
     for(int i=0; i<indentation; i++) special_log(' '); } special_log(c); if(c == 10) doindent = true; if(c == 10 && debugfile) fflush(debugfile); }
-  virtual char read_char() { throw hstream_exception(); }
+  char read_char() override { throw hstream_exception(); }
   };
 
 extern logger hlog;
@@ -278,11 +278,11 @@ inline void print(hstream& hs, cellwalker cw) {
 struct indenter {
   dynamicval<int> ind;
   
-  indenter(int i = 2) : ind(hlog.indentation, hlog.indentation + (i)) {}
+  explicit indenter(int i = 2) : ind(hlog.indentation, hlog.indentation + (i)) {}
   };
 
 struct indenter_finish : indenter {
-  indenter_finish(bool b = true): indenter(b ? 2:0) {}
+  explicit indenter_finish(bool b = true): indenter(b ? 2:0) {}
   ~indenter_finish() { if(hlog.indentation != ind.backup) println(hlog, "(done)"); }
   };
 

--- a/hyper_function.h
+++ b/hyper_function.h
@@ -19,10 +19,10 @@ template<class T, class R, class... Args>
 struct function_state : function_state_base<R, Args...> {
     T t_;
     explicit function_state(T t) : t_(std::move(t)) {}
-    R call(Args... args) const /*override*/ {
+    R call(Args... args) const override {
         return const_cast<T&>(t_)(static_cast<Args&&>(args)...);
     }
-    function_state_base<R, Args...> *clone() const /*override*/ {
+    function_state_base<R, Args...> *clone() const override {
         return new function_state(*this);
     }
 };

--- a/inforder.cpp
+++ b/inforder.cpp
@@ -21,7 +21,7 @@ EX namespace inforder {
 
   struct hrmap_inforder : hrmap_hyperbolic {
 
-    heptagon *create_step(heptagon *h, int direction) {
+    heptagon *create_step(heptagon *h, int direction) override {
       int deg = h->type;
       if(mixed()) deg = 7 - deg;
       auto h1 = init_heptagon(deg);

--- a/kite.cpp
+++ b/kite.cpp
@@ -339,7 +339,7 @@ struct hrmap_kite : hrmap {
     return gm * where;
     }
 
-  virtual int wall_offset(cell *c) {
+  int wall_offset(cell *c) override {
     if(WDIM == 3)
       return kite::getshape(c->master) == kite::pKite ? 10 : 0;
     else

--- a/pattern2.cpp
+++ b/pattern2.cpp
@@ -664,10 +664,10 @@ EX namespace patterns {
       si.reflect = false;
       }
     else {
-      int ids = 0, tids = 0, td = 0;
+      int ids = 0, td = 0;
       for(int i=0; i<S3; i++) {
         int d = c->move(2*i)->master->fieldval;
-        ids |= (1<<d); tids += d;
+        ids |= (1<<d);
         }
       for(int i=0; i<S3; i++) {
         int d = c->move(2*i)->master->fieldval;

--- a/quotient.cpp
+++ b/quotient.cpp
@@ -64,16 +64,16 @@ struct hrmap_quotient : hrmap_standard {
   
   void build();
   
-  hrmap_quotient() {
+  explicit hrmap_quotient() {
     generate_connections();    
     build();
     }
 
-  hrmap_quotient(const vector<int>& con) : connections(con) {
+  explicit hrmap_quotient(const vector<int>& con) : connections(con) {
     build();
     }
 
-  heptagon *getOrigin() { return allh[0]; }
+  heptagon *getOrigin() override { return allh[0]; }
 
   ~hrmap_quotient() {
     for(int i=0; i<isize(allh); i++) {
@@ -82,7 +82,7 @@ struct hrmap_quotient : hrmap_standard {
       }
     }
   
-  vector<cell*>& allcells() { return celllist; }
+  vector<cell*>& allcells() override { return celllist; }
   };
 #endif
   

--- a/reg3.cpp
+++ b/reg3.cpp
@@ -649,7 +649,7 @@ EX namespace reg3 {
     int h_id;
     /** transition matrix to that heptagon */
     transmatrix T;
-    /** the sequence of moves we need to make to get there */;
+    /** the sequence of moves we need to make to get there */
     vector<int> move_sequence;
     };
   
@@ -680,7 +680,7 @@ EX namespace reg3 {
       return cgi.subshapes[id].vertices_only_local;
       }
 
-    transmatrix master_relative(cell *c, bool get_inverse) {
+    transmatrix master_relative(cell *c, bool get_inverse) override {
       int id = local_id.at(c).second;
       auto& ss = cgi.subshapes[id];
       return get_inverse ? ss.from_cellcenter : ss.to_cellcenter;
@@ -689,11 +689,11 @@ EX namespace reg3 {
     void make_subconnections();
     
     int wall_offset(cell *c) override;
-    int shvid(cell *c) { return local_id.at(c).second; }
+    int shvid(cell *c) override { return local_id.at(c).second; }
     
-    virtual transmatrix ray_iadj(cell *c, int i) override;
+    transmatrix ray_iadj(cell *c, int i) override;
 
-    const vector<bool>& adjacent_dirs(cell *c, int i) { 
+    const vector<bool>& adjacent_dirs(cell *c, int i) override {
       int id = local_id.at(c).second;
       return cgi.subshapes[id].dirs_adjacent[i];
       }
@@ -1490,7 +1490,7 @@ EX namespace reg3 {
       return cgi.vertices_only;
       }
 
-    const vector<bool>& adjacent_dirs(cell *c, int i) { 
+    const vector<bool>& adjacent_dirs(cell *c, int i) override {
       return cgi.dirs_adjacent[i];
       }
 
@@ -1582,7 +1582,7 @@ EX namespace reg3 {
       clearfrom(allh[0]);
       }    
 
-    virtual struct transmatrix relative_matrix(heptagon *h2, heptagon *h1, const hyperpoint& hint) override {
+    struct transmatrix relative_matrix(heptagon *h2, heptagon *h1, const hyperpoint& hint) override {
       return iso_inverse(locations[h1->fieldval]) * locations[h2->fieldval];
       }
 
@@ -1901,13 +1901,13 @@ EX namespace reg3 {
       return relative_matrix_via_masters(c2, c1, hint);
       }
     
-    transmatrix master_relative(cell *c, bool get_inverse) {
+    transmatrix master_relative(cell *c, bool get_inverse) override {
       if(PURE) return Id;
       int aid = cell_id.at(c);
       return quotient_map->master_relative(quotient_map->acells[aid], get_inverse);
       }
 
-    int shvid(cell *c) {
+    int shvid(cell *c) override {
       if(PURE) return 0;
       if(!cell_id.count(c)) return quotient_map->shvid(c);
       int aid = cell_id.at(c);
@@ -1963,14 +1963,14 @@ EX namespace reg3 {
       c->c.connect(d, c1, ac->c.spin(d), false);
       }
 
-    virtual transmatrix ray_iadj(cell *c, int i) {
+    transmatrix ray_iadj(cell *c, int i) override {
       if(PURE) return iadj(c, i);
       if(!cell_id.count(c)) return quotient_map->ray_iadj(c, i); /* necessary because ray samples are from quotient_map */
       int aid = cell_id.at(c);
       return quotient_map->ray_iadj(quotient_map->acells[aid], i);
       }
 
-    const vector<bool>& adjacent_dirs(cell *c, int i) { 
+    const vector<bool>& adjacent_dirs(cell *c, int i) override { 
       if(PURE) return cgi.dirs_adjacent[i];
       int aid = cell_id.at(c);
       return quotient_map->adjacent_dirs(quotient_map->acells[aid], i);

--- a/sky.cpp
+++ b/sky.cpp
@@ -24,11 +24,11 @@ struct sky_item {
 
 struct dqi_sky : drawqueueitem {
   vector<sky_item> sky;
-  void draw();
-  virtual color_t outline_group() { return 3; }
+  void draw() override;
+  color_t outline_group() override { return 3; }
   // singleton
-  dqi_sky() { hr::sky = this; }
-  ~dqi_sky() { hr::sky = NULL; }
+  explicit dqi_sky() { hr::sky = this; }
+  ~dqi_sky() override { hr::sky = NULL; }
   };
   
 EX struct dqi_sky *sky;

--- a/sphere.cpp
+++ b/sphere.cpp
@@ -139,14 +139,14 @@ struct hrmap_spherical : hrmap_standard {
     #endif
     }
 
-  heptagon *getOrigin() { return dodecahedron[0]; }
+  heptagon *getOrigin() override { return dodecahedron[0]; }
 
   ~hrmap_spherical() {
     for(int i=0; i<spherecells(); i++) clearHexes(dodecahedron[i]);
     for(int i=0; i<spherecells(); i++) tailored_delete(dodecahedron[i]);
     }    
 
-  void verify() {
+  void verify() override {
     for(int i=0; i<spherecells(); i++) for(int k=0; k<S7; k++) {
       heptspin hs(dodecahedron[i], k, false);
       heptspin hs2 = hs + wstep + (S7-1) + wstep + (S7-1) + wstep + (S7-1);
@@ -172,7 +172,7 @@ struct hrmap_spherical : hrmap_standard {
     return Id;
     }
   
-  transmatrix relative_matrix(cell *c2, cell *c1, const hyperpoint& hint) {
+  transmatrix relative_matrix(cell *c2, cell *c1, const hyperpoint& hint) override {
     transmatrix T = iso_inverse(get_where(c1)) * get_where(c2);
     if(elliptic) fixelliptic(T);
     return T;


### PR DESCRIPTION
`-Woverloaded-virtual` trips here:
```
./reg3.cpp:1585:24: error: 'hr::reg3::hrmap_sphere3::relative_matrix' hides overloaded virtual function [-Werror,-Woverloaded-virtual]
    struct transmatrix relative_matrix(heptagon *h2, heptagon *h1, const hyperpoint& hint) override {
                       ^
reg3.cpp:672:17: note: hidden overloaded virtual function 'hr::reg3::hrmap_closed3::relative_matrix' declared here: type mismatch at 1st parameter ('hr::cell *' vs 'hr::heptagon *')
    transmatrix relative_matrix(cell *h2, cell *h1, const hyperpoint& hint) override;
                ^
```
IMHO the proper way to fix this would be to _stop overloading;_ instead, pick two different names for these two virtual functions. For example, `relative_matrix_cell` and `relative_matrix_hept`. Not coincidentally, see my recent C++Now presentation titled ["When Should You Give Two Things the Same Name?"](https://www.youtube.com/watch?v=OQgFEkgKx2s)
However, for this PR I've just suppressed the warning (I hope "temporarily").