### PR TITLE
Fix UB when shuffling empty vecs

### DIFF
--- a/bigstuff.cpp
+++ b/bigstuff.cpp
@@ -2001,8 +2001,8 @@ EX void generate_mines() {
   for(cell *c: currentmap->allcells())
     if(c->wall == waMineUnknown) 
       candidates.push_back(c);
+  hrandom_shuffle(candidates);
   bounded_mine_max = isize(candidates);
-  hrandom_shuffle(&candidates[0], bounded_mine_max);
   bounded_mine_quantity = int(bounded_mine_max * bounded_mine_percentage + 0.5);
   for(int i=0; i<bounded_mine_quantity; i++) candidates[i]->wall = waMineMine;
   }

--- a/complex.cpp
+++ b/complex.cpp
@@ -1847,7 +1847,7 @@ EX namespace hive {
         }
       }
     
-    hrandom_shuffle(&bugtomove[0], isize(bugtomove));
+    hrandom_shuffle(bugtomove);
     sort(bugtomove.begin(), bugtomove.end());
     
     int battlecount = 0;
@@ -3611,7 +3611,7 @@ EX namespace windmap {
     vector<bool> inqueue(N, true);
     vector<int> tocheck;
     for(int i=0; i<N; i++) tocheck.push_back(i);
-    hrandom_shuffle(&tocheck[0], isize(tocheck));
+    hrandom_shuffle(tocheck);
     
     for(int a=0; a<isize(tocheck); a++) {
       if(a >= 200*N) { printf("does not converge\n"); break; }

--- a/complex2.cpp
+++ b/complex2.cpp
@@ -852,7 +852,7 @@ EX void ambush(cell *c, int dogs) {
   int v = valence();
   if(v > 4) {
     for(cell *c: cl.lst) if(cl.getdist(c) == d) around.push_back(c);
-    hrandom_shuffle(&around[0], isize(around));
+    hrandom_shuffle(around);
     }
   else {
     for(int tries=0; tries<10000; tries++) {

--- a/game.cpp
+++ b/game.cpp
@@ -44,7 +44,7 @@ EX int hrand(int i) {
 #if HDR
 template<class T, class... U> T pick(T x, U... u) { std::initializer_list<T> i = {x,u...}; return *(i.begin() + hrand(1+sizeof...(u))); }
 template<class T> void hrandom_shuffle(T* x, int n) { for(int k=1; k<n; k++) swap(x[k], x[hrand(k+1)]); }
-template<class T> void hrandom_shuffle(T& container) { hrandom_shuffle(&container[0], isize(container)); }
+template<class T> void hrandom_shuffle(T& container) { hrandom_shuffle(container.data(), isize(container)); }
 template<class U> auto hrand_elt(U& container) -> decltype(container[0]) { return container[hrand(isize(container))]; }
 template<class T, class U> T hrand_elt(U& container, T default_value) { 
   if(container.empty()) return default_value; 

--- a/racing.cpp
+++ b/racing.cpp
@@ -331,7 +331,7 @@ void find_track(cell *start, int sign, int len) {
   }
 
 EX void block_cells(vector<cell*> to_block, function<bool(cell*)> blockbound) {
-  hrandom_shuffle(&to_block[0], isize(to_block));
+  hrandom_shuffle(to_block);
   
   for(cell *c: to_block) switch(specialland) {
     case laIce:

--- a/rogueviz/kohonen.cpp
+++ b/rogueviz/kohonen.cpp
@@ -1253,7 +1253,7 @@ void fillgroups() {
   do_classify();
   vector<int> samples_to_sort;
   for(int i=0; i<samples; i++) samples_to_sort.push_back(i);
-  hrandom_shuffle(&samples_to_sort[0], samples);
+  hrandom_shuffle(samples_to_sort);
   for(int i=0; i<samples; i++) if(net[bids[i]].drawn_samples < net[bids[i]].max_group_here)
     showsample(i);
   distribute_neurons();


### PR DESCRIPTION
Fixes UBSan `runtime error: reference binding to null pointer of type 'hr::hive::bugtomove_t'`

The issue:
* The vector `bugtomove` can be empty
* A vector can be backed by nullptr when empty
* Taking a C++ reference to a null pointer is UB (even if nothing is done with the reference)

The solution:
* Use `v.data()` as a [safe](https://en.cppreference.com/w/cpp/container/vector/data) alternative to `&v[0]`. It is a pointer instead of a reference, so it is okay for it to be null.