### PR TITLE
Fix typo in Windy Plains description

### DIFF
--- a/classes.cpp
+++ b/classes.cpp
@@ -217,7 +217,7 @@ const char *winddesc =
   "Cells which are blocked by walls, or at distance at most 2 from an Air Elemental, "
   "do not count for this.\n\n"
   "It is illegal to move in a direction which is closer to incoming wind than to "
-  "outcoming wind. However, you can move two cells with the wind in a single turn, "
+  "outgoing wind. However, you can move two cells with the wind in a single turn, "
   "and so can the birds.";
 
 const char *warningdesc = 

--- a/language-cz.cpp
+++ b/language-cz.cpp
@@ -3277,7 +3277,7 @@ S(
   "Cells which are blocked by walls, or at distance at most 2 from an Air Elemental, "
   "do not count for this.\n\n"
   "It is illegal to move in a direction which is closer to incoming wind than to "
-  "outcoming wind. However, you can move two cells with the wind in a single turn, "
+  "outgoing wind. However, you can move two cells with the wind in a single turn, "
   "and so can the birds.",
 
   "Někdo umístil na tuto pláň větráky, díky kterým tu všude vanou silné větry. "

--- a/language-de.cpp
+++ b/language-de.cpp
@@ -3070,7 +3070,7 @@ S("Someone has put air fans in these plains, causing strong winds everywhere. "
   "Cells which are blocked by walls, or at distance at most 2 from an Air Elemental, "
   "do not count for this.\n\n"
   "It is illegal to move in a direction which is closer to incoming wind than to "
-  "outcoming wind. However, you can move two cells with the wind in a single turn, "
+  "outgoing wind. However, you can move two cells with the wind in a single turn, "
   "and so can the birds.",
 
   "Jemand hat Ventilatoren in diese Ebenen gebracht, die überall starke Winde hervorrufen. "

--- a/language-pl.cpp
+++ b/language-pl.cpp
@@ -3211,7 +3211,7 @@ S(
   "Cells which are blocked by walls, or at distance at most 2 from an Air Elemental, "
   "do not count for this.\n\n"
   "It is illegal to move in a direction which is closer to incoming wind than to "
-  "outcoming wind. However, you can move two cells with the wind in a single turn, "
+  "outgoing wind. However, you can move two cells with the wind in a single turn, "
   "and so can the birds.",
 
   "Ktoś porozstawiał wentylatory na tych równinach, powodując wszędzie silne wiatry. "

--- a/language-ptbr.cpp
+++ b/language-ptbr.cpp
@@ -3302,7 +3302,7 @@ S(
   "Cells which are blocked by walls, or at distance at most 2 from an Air Elemental, "
   "do not count for this.\n\n"
   "It is illegal to move in a direction which is closer to incoming wind than to "
-  "outcoming wind. However, you can move two cells with the wind in a single turn, "
+  "outgoing wind. However, you can move two cells with the wind in a single turn, "
   "and so can the birds.",
 
   "Ktoś porozstawiał wentylatory na tych równinach, powodując wszędzie silne wiatry. "

--- a/language-ru.cpp
+++ b/language-ru.cpp
@@ -3266,7 +3266,7 @@ S(
   "Cells which are blocked by walls, or at distance at most 2 from an Air Elemental, "
   "do not count for this.\n\n"
   "It is illegal to move in a direction which is closer to incoming wind than to "
-  "outcoming wind. However, you can move two cells with the wind in a single turn, "
+  "outgoing wind. However, you can move two cells with the wind in a single turn, "
   "and so can the birds.",
  
   "Кто-то расставил вентиляторы на этой равнине и вызвал сильные ветры. "


### PR DESCRIPTION
"outcoming wind" -> "outgoing wind" (pointed out by Ann)

And changing the English string in the translation files, because I don't think this change requires re-translation.﻿
