### PR TITLE
Copy wparam when copying wall

### DIFF
--- a/monstermove.cpp
+++ b/monstermove.cpp
@@ -182,6 +182,7 @@ EX void moveMonster(const movei& mi) {
   if(isLeader(m)) {
     if(ct->wall == waBigStatue) {
       ct->wall = cf->wall;
+      ct->wparam = cf->wparam;
       cf->wall = waBigStatue;
       animateMovement(mi.rev(), LAYER_BOAT);
       }

--- a/pcmove.cpp
+++ b/pcmove.cpp
@@ -818,6 +818,7 @@ bool pcmove::after_escape() {
     changes.ccell(cwt.at);
     
     c2->wall = cwt.at->wall;
+    c2->wparam = cwt.at->wparam;
     if(doesnotFall(cwt.at)) {
       cwt.at->wall = what;
       if(cellHalfvine(what)) 
@@ -1103,8 +1104,10 @@ bool pcmove::perform_actual_move() {
     flipplayer = true; if(multi::players > 1) multi::flipped[multi::cpid] = true;
     });
   if(c2->item && isAlch(c2)) {
-    if(alchMayDuplicate(cwt.at->wall))
+    if(alchMayDuplicate(cwt.at->wall)) {
       c2->wall = cwt.at->wall;
+      c2->wparam = cwt.at->wparam;
+      }
     else
       c2->wall = waNone;
     }


### PR DESCRIPTION
Make {big-statue-of-cthulhu wall swaps, slime-and-dead-orb wall duplication} copy wparam when copying wall.

* For 'stone statues' (created when killing a monster with Orb of the Stone), the color is preserved, which is important because we don't want `celldrawer::setcolors` to read past the end of minf[]
* For other wall types that use wparam, this is probably an improvement over 'usually 0 but not guaranteed'
