### PR TITLE
Peace mode: don't switch places with dice

### DIFF
--- a/attack.cpp
+++ b/attack.cpp
@@ -1059,7 +1059,7 @@ EX bool should_switchplace(cell *c1, cell *c2) {
   if(isPrincess(c2->monst) || among(c2->monst, moGolem, moIllusion, moMouse, moFriendlyGhost))
     return true;
   
-  if(peace::on) return c2->monst && !isMultitile(c2->monst);
+  if(peace::on) return c2->monst && !isMultitile(c2->monst) && !isDie(c2->monst);
   return false;
   }
 


### PR DESCRIPTION
This prevents a crash due to the dice map not having an entry for the Animated Die's new location.

However, it allows the player to occupy the same cell as an Animated Die, which is weird, so I'm not sure this is the best solution.
