### PR TITLE
Rose scent can now force the player's allies to walk into rosebushes

### DIFF
--- a/monstermove.cpp
+++ b/monstermove.cpp
@@ -1596,8 +1596,8 @@ EX int movevalue(eMonster m, cell *c, int dir, flagtype flags) {
     if(b) val = 50;
     else if(tk2 > tk) val += 1000 + 200 * (tk2 - tk);
     }
-  else if(passable_for(m, c2, c, P_DEADLY)) val = -1100;
-  else val = -1750;
+  else if(passable_for(m, c2, c, P_DEADLY)) return -1100;
+  else return -1750;
 
   if(c->monst == moGolem ) {
     val -= c2->pathdist;


### PR DESCRIPTION
Allies were incorrectly evaluating "move against scent" as a better move than "walk into rosebush". For example, friendly golems would evaluate:

* "Move against scent" as a flat -1200
* "Walk into rosebush" as -1100, but then changed to -1225 due to subtracting [c2->pathdist = PINFD = 125]

This change restores the intended behavior (allies can be forced to walk into the rosebush's thorns) by returning the -1100 unmodified.