### PR TITLE
ASCII monsters: don't draw stun stars for Mutant Ivy

### DIFF
--- a/graph.cpp
+++ b/graph.cpp
@@ -1345,7 +1345,7 @@ EX bool drawMonsterType(eMonster m, cell *where, const shiftmatrix& V1, color_t 
   #if CAP_SHAPES
   if(among(m, moTortoise, moWorldTurtle) && where && where->stuntime >= 3)
     drawStunStars(V, where->stuntime-2);
-  else if (among(m, moTortoise, moWorldTurtle) || m == moPlayer || (where && !where->stuntime)) ;
+  else if (among(m, moTortoise, moWorldTurtle, moMutant) || m == moPlayer || (where && !where->stuntime)) ;
   else if(where && !(isMetalBeast(m) && where->stuntime == 1))
     drawStunStars(V, where->stuntime);
   


### PR DESCRIPTION
stuntime has a special meaning for Mutant Ivy, so it shouldn't be drawn with stun stars
