### PR TITLE
Allow Orb of Slaying to appear in Cursed Canyon as a prize orb

### DIFF
--- a/orbgen.cpp
+++ b/orbgen.cpp
@@ -297,7 +297,7 @@ EX eOrbLandRelation getOLR(eItem it, eLand l) {
 
   if(it == itOrbSlaying && !among(l, 
     laMirror, laHell, laEmerald, laDryForest, laCamelot, laPalace, laStorms, laRose, laTortoise, laBurial, laDungeon, laReptile, 
-    laPrairie, laBull, laVolcano, laTerracotta, laRuins, laVariant, laEclectic, laBrownian))
+    laPrairie, laBull, laVolcano, laTerracotta, laRuins, laVariant, laEclectic, laBrownian, laCursed))
     return olrUseless;
   
   if(l == laCocytus)


### PR DESCRIPTION
Orb of Slaying is useful in Cursed Canyon as a way to counter the Curse of Weakness.
