### PR TITLE
Adc

### DIFF
--- a/graph.cpp
+++ b/graph.cpp
@@ -45,7 +45,24 @@ EX bool hide_player() {
      ;
   }
 
-#define ADC(V,c) if (auto *it = hr::find_or_null(current_display->all_drawn_copies, c)) for(const shiftmatrix& V: it->second)
+template<class T>
+class span {
+  T *begin_ = nullptr;
+  T *end_ = nullptr;
+
+  public:
+  explicit span() = default;
+  explicit span(T *p, int n) : begin_(p), end_(p + n) {}
+  T *begin() const { return begin_; }
+  T *end() const { return end_; }
+  };
+
+template<class Map, class Key>
+hr::span<const shiftmatrix> span_at(const Map& map, const Key& key) {
+  auto it = map.find(key);
+  return (it == map.end()) ? hr::span<const shiftmatrix>() : hr::span<const shiftmatrix>(it->second.data(), it->second.size());
+  }
+#define ADC(V,c) for (const shiftmatrix& V : hr::span_at(current_display->all_drawn_copies, c))
 
 EX hookset<bool(int sym, int uni)> hooks_handleKey;
 EX hookset<bool(cell *c, const shiftmatrix& V)> hooks_drawcell;

--- a/graph.cpp
+++ b/graph.cpp
@@ -45,7 +45,7 @@ EX bool hide_player() {
      ;
   }
 
-#define ADC(V,c) IF_KEY_EXISTS(it, current_display->all_drawn_copies, c) for(const shiftmatrix& V: it->second)
+#define ADC(V,c) if (auto *it = hr::find_or_null(current_display->all_drawn_copies, c)) for(const shiftmatrix& V: it->second)
 
 EX hookset<bool(int sym, int uni)> hooks_handleKey;
 EX hookset<bool(cell *c, const shiftmatrix& V)> hooks_drawcell;

--- a/hyper.h
+++ b/hyper.h
@@ -575,11 +575,6 @@ typedef function<int(struct cell*)> cellfunction;
 #define forCellCM(ct, cf) forCellIdCM(ct,forCellCM ## __LINE__,cf)
 #define forCellAll(ct, cf) forCellIdCM(ct,forCellAll ## __LINE__,cf)
 
-/* conditions */
-
-/** `IF_KEY_EXISTS(it, map, key) statement` checks whether the map 'map' contain key 'key', and if so, executes statement with it set to the relevant iterator */
-#define IF_KEY_EXISTS(it, map, key) for(auto it: {map.find(key)}) if(it != map.end())
-
 // canAttack/moveval flags
 
 #define AF_NORMAL            0          // nothing special about this attack
@@ -850,6 +845,13 @@ template<class T, class U> void eliminate_if(vector<T>& data, U pred) {
 template<class T> array<T, 4> make_array(T a, T b, T c, T d) { array<T,4> x; x[0] = a; x[1] = b; x[2] = c; x[3] = d; return x; }
 template<class T> array<T, 3> make_array(T a, T b, T c) { array<T,3> x; x[0] = a; x[1] = b; x[2] = c; return x; }
 template<class T> array<T, 2> make_array(T a, T b) { array<T,2> x; x[0] = a; x[1] = b; return x; }
+
+// Find in a std::map or std::unordered_map, or return null.
+template<class Map, class Key>
+const typename Map::value_type *find_or_null(const Map& map, const Key& key) {
+  auto it = map.find(key);
+  return (it == map.end()) ? nullptr : &*it;
+  }
 
 namespace daily {
   extern bool on;

--- a/hyper.h
+++ b/hyper.h
@@ -848,9 +848,9 @@ template<class T> array<T, 2> make_array(T a, T b) { array<T,2> x; x[0] = a; x[1
 
 // Find in a std::map or std::unordered_map, or return null.
 template<class Map, class Key>
-const typename Map::value_type *find_or_null(const Map& map, const Key& key) {
+const typename Map::mapped_type *at_or_null(const Map& map, const Key& key) {
   auto it = map.find(key);
-  return (it == map.end()) ? nullptr : &*it;
+  return (it == map.end()) ? nullptr : &it->second;
   }
 
 namespace daily {

--- a/util.cpp
+++ b/util.cpp
@@ -207,10 +207,10 @@ cld exp_parser::parse(int prio) {
     cld c = rparse(0);
     force_eat(")");
 
-    if (auto *it = hr::find_or_null(extra_params, "angleunit")) {
-      a *= it->second;
-      b *= it->second;
-      c *= it->second;
+    if (auto *angleunit = hr::at_or_null(extra_params, "angleunit")) {
+      a *= *angleunit;
+      b *= *angleunit;
+      c *= *angleunit;
       }
 
     return edge_of_triangle_with_angles(real(a), real(b), real(c));
@@ -237,14 +237,14 @@ cld exp_parser::parse(int prio) {
     test.compute_sum();
     test.compute_geometry();
     res = test.edgelength;
-    if (auto *it = hr::find_or_null(extra_params, "distunit"))
-      res /= it->second;
+    if (auto *distunit = hr::at_or_null(extra_params, "distunit"))
+      res /= *distunit;
     }
   #endif
   else if(eat("regangle(")) {
     cld edgelen = parse(0);
-    if (auto *it = hr::find_or_null(extra_params, "distunit")) {
-      edgelen = edgelen * it->second;
+    if (auto *distunit = hr::at_or_null(extra_params, "distunit")) {
+      edgelen *= *distunit;
       }
     
     force_eat(",");
@@ -260,14 +260,14 @@ cld exp_parser::parse(int prio) {
     
     if(arb::legacy) {
       res = M_PI - result;
-      if (auto *it = hr::find_or_null(extra_params, "angleofs"))
-        res -= it->second;
+      if (auto *angleofs = hr::at_or_null(extra_params, "angleofs"))
+        res -= *angleofs;
       }
     else
       res = result;
 
-    if (auto *it = hr::find_or_null(extra_params, "angleunit"))
-      res /= it->second;
+    if (auto *angleunit = hr::at_or_null(extra_params, "angleunit"))
+      res /= *angleunit;
     }
   else if(eat("test(")) {
     res = parsepar();
@@ -318,8 +318,8 @@ cld exp_parser::parse(int prio) {
   else if(next() == '(') at++, res = parsepar(); 
   else {
     string number = next_token();
-    if (auto *it = hr::find_or_null(extra_params, number)) res = it->second;
-    else if (auto *it = hr::find_or_null(params, number)) res = it->second->get_cld();
+    if (auto *p = hr::at_or_null(extra_params, number)) res = *p;
+    else if (auto *p = hr::at_or_null(params, number)) res = (*p)->get_cld();
     else if(number == "e") res = exp(1);
     else if(number == "i") res = cld(0, 1);
     else if(number == "p" || number == "pi") res = M_PI;

--- a/util.cpp
+++ b/util.cpp
@@ -207,7 +207,7 @@ cld exp_parser::parse(int prio) {
     cld c = rparse(0);
     force_eat(")");
 
-    IF_KEY_EXISTS(it, extra_params, "angleunit") {
+    if (auto *it = hr::find_or_null(extra_params, "angleunit")) {
       a *= it->second;
       b *= it->second;
       c *= it->second;
@@ -237,13 +237,13 @@ cld exp_parser::parse(int prio) {
     test.compute_sum();
     test.compute_geometry();
     res = test.edgelength;
-    IF_KEY_EXISTS(it, extra_params, "distunit")
+    if (auto *it = hr::find_or_null(extra_params, "distunit"))
       res /= it->second;
     }
   #endif
   else if(eat("regangle(")) {
     cld edgelen = parse(0);
-    IF_KEY_EXISTS(it, extra_params, "distunit") {
+    if (auto *it = hr::find_or_null(extra_params, "distunit")) {
       edgelen = edgelen * it->second;
       }
     
@@ -260,13 +260,13 @@ cld exp_parser::parse(int prio) {
     
     if(arb::legacy) {
       res = M_PI - result;
-      IF_KEY_EXISTS(it, extra_params, "angleofs")
+      if (auto *it = hr::find_or_null(extra_params, "angleofs"))
         res -= it->second;
       }
     else
       res = result;
 
-    IF_KEY_EXISTS(it, extra_params, "angleunit")
+    if (auto *it = hr::find_or_null(extra_params, "angleunit"))
       res /= it->second;
     }
   else if(eat("test(")) {
@@ -318,8 +318,8 @@ cld exp_parser::parse(int prio) {
   else if(next() == '(') at++, res = parsepar(); 
   else {
     string number = next_token();
-    IF_KEY_EXISTS(it, extra_params, number) res = it->second;
-    else IF_KEY_EXISTS(it, params, number) res = it->second->get_cld();
+    if (auto *it = hr::find_or_null(extra_params, number)) res = it->second;
+    else if (auto *it = hr::find_or_null(params, number)) res = it->second->get_cld();
     else if(number == "e") res = exp(1);
     else if(number == "i") res = cld(0, 1);
     else if(number == "p" || number == "pi") res = M_PI;


### PR DESCRIPTION
Fixes #244.

Right now the replacement code is of the form
```
for (const shiftmatrix& V : hr::span_at(current_display->all_drawn_copies, dragon::target)) {
```
but maybe it would be nicer to make it a member function of `current_display`; what do you think?
```
for (const shiftmatrix& V : current_display->all_drawn_copies_at(dragon::target)) {
```

I didn't do that mainly because I don't know whether the preposition should be `_at` or something else. I just refactored the C++, didn't really try to understand what it _means_. ;)