### PR TITLE
Cursed Canyon no longer generates monsters in walls

### DIFF
--- a/landgen.cpp
+++ b/landgen.cpp
@@ -2632,6 +2632,7 @@ EX void giantLandSwitch(cell *c, int d, cell *from) {
               c->monst = moHexer;
               c->item = pick(itCurseWeakness, itCurseDraining, itCurseWater, itCurseFatigue, itCurseRepulsion, itCurseGluttony);
               }
+            break;
             }
           }
         


### PR DESCRIPTION
This change prevents filling a "potential turret" cell with stone and then also spawning a hexer (on the mistaken assumption that the cell is still empty).