### PR TITLE
Prevent dice overlap after an animated die rolls away

### DIFF
--- a/landgen.cpp
+++ b/landgen.cpp
@@ -2587,8 +2587,9 @@ EX void giantLandSwitch(cell *c, int d, cell *from) {
     
     case laDice: {
       #if CAP_COMPLEX2
-      if(fargen)
+      if(fargen && !c->monst && !c->wall) {
         dice::generate_full(c, items[itDice] + yendor::hardness());
+      }
       #endif
       break;
       }


### PR DESCRIPTION
This fixes an infrequent crash by preventing wall-dice from being generated on top of monster-dice (which could happen if the monster-dice pathfinding took it far away from the player, into ungenerated cells)﻿
