### PR TITLE
Fix Dice Reserve crash in geometries that support d6/d12

### DIFF
--- a/complex2.cpp
+++ b/complex2.cpp
@@ -1051,7 +1051,7 @@ EX namespace dice {
         c->wall = (pct < (items[itOrbLuck] ? 9 : 11)) ? waRichDie : waHappyDie;
         generate_specific(c, &d6, 1, 2);
         }
-      if(pct2 < 40 + hard) {
+      else if(pct2 < 40 + hard) {
         c->monst = moAnimatedDie;
         generate_specific(c, &d6, 0, 99);
         }
@@ -1062,7 +1062,7 @@ EX namespace dice {
         c->wall = (pct < (items[itOrbLuck] ? 9 : 11)) ? waRichDie : waHappyDie;
         generate_specific(c, &d12, 2, 3);
         }
-      if(pct2 < 40 + hard) {
+      else if(pct2 < 40 + hard) {
         c->monst = moAnimatedDie;
         generate_specific(c, &d12, 0, 99);
         }


### PR DESCRIPTION
Missing `else` allowed `generate_full` to put a wall-die and monster-die on the same cell. After the monster-die rolled away, the ﻿wall-die would be left without a `dice::data` entry.
