### PR TITLE
Change goblin text to account for its presence in other lands

### DIFF
--- a/language-cz.cpp
+++ b/language-cz.cpp
@@ -678,8 +678,8 @@ S("Rangers take care of the magic mirrors in the Land of Mirrors. "
  "Strážci se starají o kouzelná zrcadla v Kraji zrcadel. Vědí, že lupiči "
  "jako ty rádi tato zrcadla rozbíjejí... a proto na tebe útočí!")
 
-S("A nasty creature that lives in caves. They don't like you "
- "for some reason.",
+// TODO update translation
+S("A nasty creature that lives in caves. They don't like you for some reason.",
  "Hnusná potvora žijící v Živoucích jeskyních. Z nějakého důvodu "
  "tě nemají rády.")
 

--- a/language-cz.cpp
+++ b/language-cz.cpp
@@ -678,7 +678,7 @@ S("Rangers take care of the magic mirrors in the Land of Mirrors. "
  "Strážci se starají o kouzelná zrcadla v Kraji zrcadel. Vědí, že lupiči "
  "jako ty rádi tato zrcadla rozbíjejí... a proto na tebe útočí!")
 
-S("A nasty creature native to the Living Caves. They don't like you "
+S("A nasty creature that lives in caves. They don't like you "
  "for some reason.",
  "Hnusná potvora žijící v Živoucích jeskyních. Z nějakého důvodu "
  "tě nemají rády.")

--- a/language-de.cpp
+++ b/language-de.cpp
@@ -641,8 +641,8 @@ S("Rangers take care of the magic mirrors in the Land of Mirrors. "
   "Ranger beschützen die Zauberspiegel im Spiegelland. Sie wissen, dass Schurken wie du "
   "die Spiegel gerne zerbrechen - also greifen sie dich an!")
 
-S("A nasty creature that lives in caves. They don't like you "
-  "for some reason.",
+// TODO update translation
+S("A nasty creature that lives in caves. They don't like you for some reason.",
   "Ein grässliches Geschöpf, das in den Lebenden Höhlen haust. Irgendwie können diese Kreaturen dich nicht leiden.")
 
 S("A tribe of men native to the Desert. They have even tamed the huge Sandworms, who won't attack them.",

--- a/language-de.cpp
+++ b/language-de.cpp
@@ -641,7 +641,7 @@ S("Rangers take care of the magic mirrors in the Land of Mirrors. "
   "Ranger beschützen die Zauberspiegel im Spiegelland. Sie wissen, dass Schurken wie du "
   "die Spiegel gerne zerbrechen - also greifen sie dich an!")
 
-S("A nasty creature native to the Living Caves. They don't like you "
+S("A nasty creature that lives in caves. They don't like you "
   "for some reason.",
   "Ein grässliches Geschöpf, das in den Lebenden Höhlen haust. Irgendwie können diese Kreaturen dich nicht leiden.")
 

--- a/language-pl.cpp
+++ b/language-pl.cpp
@@ -654,8 +654,8 @@ S("Rangers take care of the magic mirrors in the Land of Mirrors. "
  "Strażnicy chronią lustra w Krainie Luster. Wiedzą, że złodzieje lubią "
  "rozbijać lustra... także spodziewaj się ataku!")
 
-S("A nasty creature that lives in caves. They don't like you "
- "for some reason.",
+// TODO update translation
+S("A nasty creature that lives in caves. They don't like you for some reason.",
  "Brzydki stwór z Żywych Jaskiń. Jakoś Cię nie lubi.")
 
 S("A tribe of men native to the Desert. They have even tamed the huge Sandworms, who won't attack them.",

--- a/language-pl.cpp
+++ b/language-pl.cpp
@@ -654,7 +654,7 @@ S("Rangers take care of the magic mirrors in the Land of Mirrors. "
  "Strażnicy chronią lustra w Krainie Luster. Wiedzą, że złodzieje lubią "
  "rozbijać lustra... także spodziewaj się ataku!")
 
-S("A nasty creature native to the Living Caves. They don't like you "
+S("A nasty creature that lives in caves. They don't like you "
  "for some reason.",
  "Brzydki stwór z Żywych Jaskiń. Jakoś Cię nie lubi.")
 

--- a/language-ptbr.cpp
+++ b/language-ptbr.cpp
@@ -670,7 +670,7 @@ S(
  "rozbijać lustra... także spodziewaj się ataku!")
 
 S(
- "A nasty creature native to the Living Caves. They don't like you "
+ "A nasty creature that lives in caves. They don't like you "
  "for some reason.",
  
  "Brzydki stwór z Żywych Jaskiń."

--- a/language-ptbr.cpp
+++ b/language-ptbr.cpp
@@ -665,14 +665,14 @@ S(
  "Rangers take care of the magic mirrors in the Land of Mirrors. "
  "They know that rogues like to break these mirrors... so "
  "they will attack you!",
- 
+
  "Strażnicy chronią lustra w Krainie Luster. Wiedzą, że złodzieje lubią "
  "rozbijać lustra... także spodziewaj się ataku!")
 
+// TODO update translation
 S(
- "A nasty creature that lives in caves. They don't like you "
- "for some reason.",
- 
+ "A nasty creature that lives in caves. They don't like you for some reason.",
+
  "Brzydki stwór z Żywych Jaskiń."
  "Jakoś Cię nie lubi.")
 

--- a/language-ru.cpp
+++ b/language-ru.cpp
@@ -651,8 +651,8 @@ S("Rangers take care of the magic mirrors in the Land of Mirrors. "
  "Странники охраняют магические зеркала. Они знают, что эти "
  "разбойники хотят разбить их зеркала и тут же нападают на Вас!")
 
-S("A nasty creature that lives in caves. They don't like you "
- "for some reason.",
+// TODO update translation
+S("A nasty creature that lives in caves. They don't like you for some reason.",
  "Противное существо из Живых пещер. По каким-то причинам не любит людей.")
 
 S("A tribe of men native to the Desert. They have even tamed the huge Sandworms, who won't attack them.",

--- a/language-ru.cpp
+++ b/language-ru.cpp
@@ -651,7 +651,7 @@ S("Rangers take care of the magic mirrors in the Land of Mirrors. "
  "Странники охраняют магические зеркала. Они знают, что эти "
  "разбойники хотят разбить их зеркала и тут же нападают на Вас!")
 
-S("A nasty creature native to the Living Caves. They don't like you "
+S("A nasty creature that lives in caves. They don't like you "
  "for some reason.",
  "Противное существо из Живых пещер. По каким-то причинам не любит людей.")
 

--- a/language-tr.cpp
+++ b/language-tr.cpp
@@ -608,8 +608,8 @@ S("Rangers take care of the magic mirrors in the Land of Mirrors. "
  "they will attack you!",
  "Seyyahların aynalarını kıracağını bildiklerinden sana saldıracaklar!")
 
-S("A nasty creature that lives in caves. They don't like you "
- "for some reason.",
+// TODO update translation
+S("A nasty creature that lives in caves. They don't like you for some reason.",
  "Yaşayan Mağaralarda yaşayan iğrenç bir yaratık. Nedense seni hiç sevmiyor.")
 
 S("A tribe of men native to the Desert. They have even tamed the huge Sandworms, who won't attack them.",

--- a/language-tr.cpp
+++ b/language-tr.cpp
@@ -608,7 +608,7 @@ S("Rangers take care of the magic mirrors in the Land of Mirrors. "
  "they will attack you!",
  "Seyyahların aynalarını kıracağını bildiklerinden sana saldıracaklar!")
 
-S("A nasty creature native to the Living Caves. They don't like you "
+S("A nasty creature that lives in caves. They don't like you "
  "for some reason.",
  "Yaşayan Mağaralarda yaşayan iğrenç bir yaratık. Nedense seni hiç sevmiyor.")
 


### PR DESCRIPTION
The message for the Goblin enemy currently appears as:
![screenshot of goblin's flavor text](https://cdn.discordapp.com/attachments/550649218885353472/866621928546762801/unknown.png)

However Goblins also appear in the Dead Cave (as shown in the screenshot). This PR implements my suggestion from the HyperRogue discord to replace "Living Cave" with "caves" more generally.