### PR TITLE
Princess Quest no longer shows fail screen merely due to the princess being in peril

### DIFF
--- a/attack.cpp
+++ b/attack.cpp
@@ -527,7 +527,7 @@ EX void killMonster(cell *c, eMonster who, flagtype deathflags IS(0)) {
           princess::reviveAt = gold(NO_LOVE) + 20;
           }
         }
-      if(princess::challenge) showMissionScreen();
+      if(princess::challenge) changes.at_commit([] { showMissionScreen(); });
       }
     }
 


### PR DESCRIPTION
Fixes a bug reported on Discord by DivisionByZero: the princess being in peril (e.g. the player is on a trapdoor and could force an adjacent princess to swap) shouldn't show the menu as if the princess actually died.