### PR TITLE
Adjust Snake Nest colors so drawMonster can add them without overflowing to black

### DIFF
--- a/graph.cpp
+++ b/graph.cpp
@@ -3362,7 +3362,7 @@ ld wavefun(ld x) {
   else return 0; */
   }
 
-EX colortable nestcolors = { 0x800000, 0x008000, 0x000080, 0x404040, 0x700070, 0x007070, 0x707000, 0x606060 };
+EX colortable nestcolors = { 0x7F0000, 0x007F00, 0x00007F, 0x404040, 0x700070, 0x007070, 0x707000, 0x606060 };
 
 color_t floorcolors[landtypes];
 

--- a/graph.cpp
+++ b/graph.cpp
@@ -3362,7 +3362,9 @@ ld wavefun(ld x) {
   else return 0; */
   }
 
-EX colortable nestcolors = { 0x7F0000, 0x007F00, 0x00007F, 0x404040, 0x700070, 0x007070, 0x707000, 0x606060 };
+// Color components in nestcolors must be less than 0x80 (for addition in drawMonster for Rock Snakes)
+// and must be divisible by 4 (for brightening of raised cells in celldrawer::setcolors)
+EX colortable nestcolors = { 0x7C0000, 0x007C00, 0x00007C, 0x404040, 0x700070, 0x007070, 0x707000, 0x606060 };
 
 color_t floorcolors[landtypes];
 


### PR DESCRIPTION
drawMonster has:

```
      int c1 = nestcolors[pattern_threecolor(c)];
      int c2 = nestcolors[pattern_threecolor(c->move(d))];
      col = (c1 + c2); // sum works because they are dark and should be brightened
```

So, the colors in nestcolors need to have each color component below 0x80 in order for the snakes not appear black.
