### PR TITLE
Fix highlight colors for snakes

### DIFF
--- a/graph.cpp
+++ b/graph.cpp
@@ -2550,12 +2550,15 @@ EX bool drawMonster(const shiftmatrix& Vparam, int ct, cell *c, color_t col, col
   #if CAP_SHAPES
 
   bool darkhistory = history::includeHistory && history::inkillhistory.count(c);
-  
-  if(doHighlight())
-    poly_outline = 
+  color_t outline = OUTLINE_NONE;
+
+  if(doHighlight()) {
+    outline =
       (isPlayerOn(c) || isFriendly(c)) ? OUTLINE_FRIEND : 
       noHighlight(c->monst) ? OUTLINE_NONE :
       OUTLINE_ENEMY;
+    poly_outline = outline;
+    }
     
   // highlight faraway enemies if that's needed
   if (vid.faraway_highlight && c->cpdist >= 6 && vid.faraway_highlight <= get_threat_level(c)) {
@@ -2677,6 +2680,8 @@ EX bool drawMonster(const shiftmatrix& Vparam, int ct, cell *c, color_t col, col
           add_segment(taildist(c), [=] () {
             for(int i=11; i>=0; i--) {
               if(i < 3 && (c->monst == moTentacle || c->monst == moTentaclewait)) continue;
+              if(doHighlight())
+                poly_outline = outline;
               shiftmatrix Vbx = Vb;
               if(WDIM == 2) Vbx = Vbx * spin(sin(M_PI * i / 6.) * wav / (i+.1));
               Vbx = Vbx * xpush(length * (i) / 12.0);


### PR DESCRIPTION
Capture outline color for the closure that draws snake segments.

This fixes two problems with the bodies of Sandworms and Rock Snakes:
* When the player had allies on-screen, snake bodies could be incorrectly highlighted in green
* When the player was mounted on a snake (Orb of Domination), the mounted snake's body was incorrectly highlighted in red
