### PR TITLE
Fix RRV snakes sometimes being colored like SN snakes

### DIFF
--- a/monstergen.cpp
+++ b/monstergen.cpp
@@ -597,7 +597,7 @@ EX void wandering() {
       if (hrand(10) || peace::on)
         c->monst = moRedTroll;
       else if (!pseudohept(c))
-        c->monst = moHexSnake;
+        c->monst = moHexSnake, c->hitpoints = 1;
       }
 
     else if(c->land == laCaves && wchance(items[itGold], 5))


### PR DESCRIPTION
Fix monstergen.cpp so wandering RRV snakes always have a `hitpoints` value of 1, indicating to `drawMonster` that they should be drawn as RRV snakes (in contrast to SN snakes, which have a `hitpoints` value of 2).