### PR TITLE
Fix color of slime on Brown Island

### DIFF
--- a/celldrawer.cpp
+++ b/celldrawer.cpp
@@ -189,15 +189,8 @@ void celldrawer::setcolors() {
 
 #if CAP_COMPLEX2
     case laBrownian: {
-      fcol = wcol = 
-        /*
-        c->landparam == 0 ? 0x0000F0 : 
-        c->landparam < level ? gradient(0x002000, 0xFFFFFF, 1, c->landparam, level-1) :
-        c->landparam < 2 * level ? 0xFFFF80 :
-        c->landparam < 3 * level ? 0xFF8000 :
-        0xC00000; */
-       
-        c->landparam == 0 ? 0x0000F0 : brownian::get_color(c->landparam);
+      if (c->wall == waNone)
+        fcol = wcol = brownian::get_color(c->landparam);
       break;
       }
 #endif


### PR DESCRIPTION
I removed the special case for `landparam == 0` because that should be covered by the isWateryOrBoat section above. I did not add special cases for waStrandedBoat or waBigStatue because I don't know the intended behavior.
