### PR TITLE
Fix terra statue interactions with Chaos+Icy, BSoC swap, Alch dup

### DIFF
--- a/celldrawer.cpp
+++ b/celldrawer.cpp
@@ -1369,7 +1369,7 @@ void celldrawer::draw_features() {
     
     case waTerraWarrior:
       #if CAP_COMPLEX2
-      drawTerraWarrior(V, terracotta::randterra ? (c->landparam & 7) : (5 - (c->landparam & 7)), 7, 0);
+      drawTerraWarrior(V, terracotta::randterra ? (c->wparam & 7) : (5 - (c->wparam & 7)), 7, 0);
       #endif
       break;
     
@@ -2222,7 +2222,7 @@ void celldrawer::draw_wall_full() {
     if(c->wall == waFireTrap)
       asciicol = trapcol[c->wparam & 3];
     if(c->wall == waTerraWarrior)
-      asciicol = terracol[c->landparam & 7];
+      asciicol = terracol[c->wparam & 7];
 
     if(c->wall == waMineOpen) {
       int mines = countMinesAround(c);

--- a/complex2.cpp
+++ b/complex2.cpp
@@ -654,15 +654,15 @@ EX void check(cell *c) {
   if(c->wall == waTerraWarrior && !c->monst && !racing::on) {
     bool live = false;
     if(randterra) {
-      c->landparam++;
-      if((c->landparam == 3 && hrand(3) == 0) ||
-        (c->landparam == 4 && hrand(2) == 0) || 
-        c->landparam == 5)
+      c->wparam++;
+      if((c->wparam == 3 && hrand(3) == 0) ||
+        (c->wparam == 4 && hrand(2) == 0) ||
+        c->wparam == 5)
           live = true;
       }
     else {
-      c->landparam--;
-      live = !c->landparam;
+      c->wparam--;
+      live = !c->wparam;
       }
     if(live)
       c->monst = moTerraWarrior,

--- a/help.cpp
+++ b/help.cpp
@@ -944,7 +944,7 @@ EX void describeMouseover() {
       out += ", "; out += XLAT1(winf[c->wall].name); 
       
       if(c->wall == waRose) out += " (" + its(7-rosephase) + ")";
-      if(c->wall == waTerraWarrior) out += " (" + its(c->landparam) + ")";
+      if(c->wall == waTerraWarrior) out += " (" + its(c->wparam) + ")";
       #if CAP_COMPLEX2
       if(isDie(c->wall)) out += " (" + dice::describe(c) + ")";
       #endif

--- a/landgen.cpp
+++ b/landgen.cpp
@@ -1198,11 +1198,11 @@ EX void giantLandSwitch(cell *c, int d, cell *from) {
           createArrowTrapAt(c, laTerracotta);
         if(pseudohept(c) && hrand(100) < 40 && c->wall == waNone && !racing::on) {
           c->wall = waTerraWarrior;
-          c->landparam = terracotta::randterra ? 0 : 3 + hrand(3);
+          c->wparam = terracotta::randterra ? 0 : 3 + hrand(3);
           if(hrand(100) < items[itTerra]-10)
-            c->landparam--;
+            c->wparam--;
           if(hrand(100) < items[itTerra]-10)
-            c->landparam--;
+            c->wparam--;
           }
         }
       if(d == 7) {


### PR DESCRIPTION
Move the terracotta statue countdown from landparam to wparam.

Fixes the following interactions for terracotta statue:
* Big Statue of Cthulhu swap (previously set countdown to 0; now maintains countdown)
* Slime duplication (previously set countdown to 0; now copies countdown)
* Statue in icy land, brought using chaos or either of the above (previously caused cursed interactions between heat value and statue countdown; now they don't interfere)
