### PR TITLE
Stop setting landparam in Hunting Ground generation

### DIFF
--- a/landgen.cpp
+++ b/landgen.cpp
@@ -2076,10 +2076,8 @@ EX void giantLandSwitch(cell *c, int d, cell *from) {
                       if(valence() != 3 || isNeighbor(dog1, dog2)) {
                         dog1->monst = moHunterGuard;
                         dog1->stuntime = 0;
-                        dog1->landparam = 0;
                         dog2->monst = moHunterGuard;
                         dog2->stuntime = 0;
-                        dog2->landparam = 1;
                         break;
                         }
                       }


### PR DESCRIPTION
* Seems to be unused: I didn't see any code related to Hunting Ground or dogs that checks landparam.
* Could leak into other lands: for example, with `./hyper -C -W Hunting -W2 Minefield -I Turquoise 1`, some dogs that generate on Minefield cells would also incorrectly mark their Minefield cell as "known mine".