### PR TITLE
Erase rosemap entries for deleted cells

### DIFF
--- a/system.cpp
+++ b/system.cpp
@@ -1706,5 +1706,8 @@ addHook(hooks_removecells, 0, [] () {
   eliminate_if(butterflies, [] (pair<cell*,int>& p) { return is_cell_removed(p.first); });
   for(int i=0; i<SHSIZE; i++) for(int p=0; p<MAXPLAYER; p++)
     set_if_removed(shpos[i][p], NULL);
+  vector<cell*> to_remove;
+  for(auto p: rosemap) if(is_cell_removed(p.first)) to_remove.push_back(p.first);
+  for(auto r: to_remove) rosemap.erase(r);
   });
 }


### PR DESCRIPTION
Modeled on the way complex2.cpp erases deleted cells from `futures`.

Fixes #295.
