### PR TITLE
Add HYPERFONTPATH to make it easier to package on Fedora.

### DIFF
--- a/basegraph.cpp
+++ b/basegraph.cpp
@@ -197,7 +197,7 @@ EX void present_screen() {
 
 #if CAP_SDLTTF
 
-EX string fontpath = ISWEB ? "sans-serif" : HYPERPATH "DejaVuSans-Bold.ttf";
+EX string fontpath = ISWEB ? "sans-serif" : HYPERFONTPATH "DejaVuSans-Bold.ttf";
 
 void loadfont(int siz) {
   fix_font_size(siz);

--- a/sysconfig.h
+++ b/sysconfig.h
@@ -347,6 +347,10 @@
 #define HYPERPATH ""
 #endif
 
+#ifndef HYPERFONTPATH
+#define HYPERFONTPATH HYPERPATH
+#endif
+
 #if ISWINDOWS
 #define hyper fake_hyper // avoid "hyper" typedef in <_mingw.h>
 #define WIN32_LEAN_AND_MEAN // avoid "rad1" macro in <windows.h>


### PR DESCRIPTION
Fedora prefers not to have multiple copies of fonts. Since the font is already installed, I need to specify a different location than the other game files. HYPERFONTPATH defaults to the same as HYPERPATH so no one needs to use it unless they are in a similar situation.

Linux has a fontconfig library that can be used to lookup a font instead of hardcoding the path. Would you be interested in a patch to add that capability to the Linux version. I used it in ostrichriders:

https://github.com/dulsi/ostrichriders/commit/0862a5c8b7f74c12c5ff931511d53cfc43ca4f66