### PR TITLE
Valentine's Easter Egg: Add +1 extra charge to Orb of Love

### DIFF
--- a/orbs.cpp
+++ b/orbs.cpp
@@ -1608,7 +1608,7 @@ bool isValentines() {
   const time_t now = time(NULL);
   const struct tm *datetime = localtime(&now);
 
-  // 0-indexed tm_mon, 1-index tm_mday
+  // 0-indexed tm_mon, 1-indexed tm_mday
   // So this is February (2nd month), and the 14th day.
   return datetime->tm_mon == 1 && datetime->tm_mday == 14;
 }

--- a/orbs.cpp
+++ b/orbs.cpp
@@ -5,7 +5,9 @@
  *  \brief Implementation of various Orb effects, and their properties such as default and maximum charges
  */
 
+#include <ctime>
 #include "hyper.h"
+
 namespace hr {
 
 EX bool orbused[ittypes], lastorbused[ittypes];
@@ -1602,6 +1604,12 @@ EX eItem targetRangedOrb(cell *c, orbAction a) {
   return itNone;
   }
 
+bool isValentines() {
+  const time_t now = time(NULL);
+  const struct tm *datetime = localtime(&now);
+  return datetime->tm_mon == 1 && datetime->tm_mday == 14;
+}
+
 EX int orbcharges(eItem it) {
   switch(it) {
     case itRevolver: //pickup-key
@@ -1611,6 +1619,7 @@ EX int orbcharges(eItem it) {
     case itOrbDiscord:
       return inv::on ? 46 : 23;
     case itOrbLove:
+      return isValentines() ? 31 : 30;
     case itOrbUndeath:
     case itOrbSpeed: //"pickup-speed");
     case itOrbInvis:

--- a/orbs.cpp
+++ b/orbs.cpp
@@ -1607,6 +1607,9 @@ EX eItem targetRangedOrb(cell *c, orbAction a) {
 bool isValentines() {
   const time_t now = time(NULL);
   const struct tm *datetime = localtime(&now);
+
+  // 0-indexed tm_mon, 1-index tm_mday
+  // So this is February (2nd month), and the 14th day.
   return datetime->tm_mon == 1 && datetime->tm_mday == 14;
 }
 


### PR DESCRIPTION
Minor date-based easter egg, something minor enough to not impact gameplay, but a fun addition.

Normally the [Orb of Love](https://hyperrogue.miraheze.org/wiki/Orb_of_Love) gives `30` charges on pickup. This change makes it so that, on Valentine's Day (February 14th), the Orb of Love instead bestows `31` charges on pickup.