### PR TITLE
Add exception for handling of "Crossroads" in wiki links

### DIFF
--- a/util.cpp
+++ b/util.cpp
@@ -732,6 +732,11 @@ EX void open_url(string s) {
   
 const char *urlhex = "0123456789ABCDEF";
 EX void open_wiki(const char *title) {
+  // Since "Crossroads" is ambiguous, we use the direct link to Crossroads I.
+  if (!strcmp(title, "Crossroads")) {
+    title = "Crossroads (Land)";
+  }
+
   string url = "https://hyperrogue.miraheze.org/wiki/";
   unsigned char c;
   for (size_t i = 0; (c = title[i]); ++i) {


### PR DESCRIPTION
As mentioned both in chat and on its [talk page](https://hyperrogue.miraheze.org/wiki/Talk:Crossroads), the `Crossroads` page is in an unusual position. Because it refers to a few different concepts (the land Crossroads, the concept of crossroads in general, or hub lands), it should be a [disambiguation page](https://hyperrogue.miraheze.org/wiki/Crossroads_(disambiguation)). However, this is not currently possible because the game links to `Crossroads` specifically for the land, and having it link to a disambiguation page would be unhelpful.

As such, the proper solution is to ensure the wiki link provided in-game is unambiguously in reference to the land "Crossroads", and then the wiki can structure itself in a manner that makes sense without worrying about disrupting game users.