### PR TITLE
Various small compiler-warning fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ ifeq (${TOOLCHAIN},clang)
   CXXFLAGS_STD = -std=c++11
   CXXFLAGS_EARLY += -fPIC
   CXXFLAGS_EARLY += -W -Wall -Wextra -Wsuggest-override -pedantic
-  CXXFLAGS_EARLY += -Wno-unused-parameter -Wno-implicit-fallthrough -Wno-maybe-uninitialized -Wno-unknown-warning-option
+  CXXFLAGS_EARLY += -Wno-unused-parameter -Wno-implicit-fallthrough -Wno-maybe-uninitialized -Wno-char-subscripts -Wno-unknown-warning-option
   CXXFLAGS_EARLY += -Wno-invalid-offsetof
 endif
 

--- a/archimedean.cpp
+++ b/archimedean.cpp
@@ -1314,7 +1314,7 @@ EX void show() {
       }
     else {
       tested.coloring = col;
-      tilings.push_back(move(tested));
+      tilings.push_back(std::move(tested));
       /* sort(tilings.begin(), tilings.end(), [] (archimedean_tiling& s1, archimedean_tiling& s2) {
         if(s1.euclidean_angle_sum < s2.euclidean_angle_sum - 1e-6) return true;
         if(s2.euclidean_angle_sum < s1.euclidean_angle_sum - 1e-6) return false;

--- a/complex.cpp
+++ b/complex.cpp
@@ -2082,7 +2082,7 @@ EX namespace heat {
         }
       }
     
-    offscreen_heat = move(offscreen2);
+    offscreen_heat = std::move(offscreen2);
   
     for(int i=0; i<numplayers(); i++) {
       cell *c = playerpos(i);
@@ -2329,7 +2329,7 @@ EX namespace heat {
         }
       }
    
-    offscreen_fire = move(offscreen2);
+    offscreen_fire = std::move(offscreen2);
     }  
 
 EX }

--- a/complex2.cpp
+++ b/complex2.cpp
@@ -148,7 +148,7 @@ EX namespace brownian {
   
   EX void apply_futures(cell *c) {
     if(futures.count(c)) {
-      auto m = move(futures[c]);
+      auto m = std::move(futures[c]);
       futures.erase(c);
       for(auto p: m)
         recurse(p.first, p.second);

--- a/crystal.cpp
+++ b/crystal.cpp
@@ -269,7 +269,7 @@ struct crystal_structure {
     next.resize(4, {2,3,1,0});
     next_to_prev();
     while(dir < S7) {
-      crystal_structure csx = move(*this);
+      crystal_structure csx = std::move(*this);
       add_dimension_to(csx);
       }
     if(dir > S7) remove_half_dimension();

--- a/drawing.cpp
+++ b/drawing.cpp
@@ -2206,13 +2206,13 @@ EX void sort_drawqueue() {
 
   #if MINIMIZE_GL_CALLS
   map<color_t, vector<unique_ptr<drawqueueitem>>> subqueue;
-  for(auto& p: ptds) subqueue[(p->prio == PPR::CIRCLE || p->prio == PPR::OUTCIRCLE) ? 0 : p->outline_group()].push_back(move(p));
+  for(auto& p: ptds) subqueue[(p->prio == PPR::CIRCLE || p->prio == PPR::OUTCIRCLE) ? 0 : p->outline_group()].push_back(std::move(p));
   ptds.clear();
-  for(auto& p: subqueue) for(auto& r: p.second) ptds.push_back(move(r));
+  for(auto& p: subqueue) for(auto& r: p.second) ptds.push_back(std::move(r));
   subqueue.clear();
-  for(auto& p: ptds) subqueue[(p->prio == PPR::CIRCLE || p->prio == PPR::OUTCIRCLE) ? 0 : p->color].push_back(move(p));
+  for(auto& p: ptds) subqueue[(p->prio == PPR::CIRCLE || p->prio == PPR::OUTCIRCLE) ? 0 : p->color].push_back(std::move(p));
   ptds.clear();
-  for(auto& p: subqueue) for(auto& r: p.second) ptds.push_back(move(r));
+  for(auto& p: subqueue) for(auto& r: p.second) ptds.push_back(std::move(r));
   #endif
     
   for(auto& p: ptds) {
@@ -2233,7 +2233,7 @@ EX void sort_drawqueue() {
   vector<unique_ptr<drawqueueitem>> ptds2;  
   ptds2.resize(siz);
   
-  for(int i = 0; i<siz; i++) ptds2[qp[int(ptds[i]->prio)]++] = move(ptds[i]);
+  for(int i = 0; i<siz; i++) ptds2[qp[int(ptds[i]->prio)]++] = std::move(ptds[i]);
   swap(ptds, ptds2);
   }
 

--- a/environment.cpp
+++ b/environment.cpp
@@ -859,7 +859,7 @@ EX void monstersTurn() {
   
   changes.value_keep(crush_now);
   changes.value_keep(crush_next);
-  crush_now = move(crush_next);
+  crush_now = std::move(crush_next);
   crush_next.clear();
   
   DEBB(DF_TURN, ("heat"));

--- a/expansion.cpp
+++ b/expansion.cpp
@@ -190,7 +190,7 @@ void expansion_analyzer::reduce_grouping() {
   for(int i=0; i<nogroups; i++) 
     for(int j: children[groupsample[i]])
       newchildren[i].push_back(grouping[j]);
-  children = move(newchildren);
+  children = std::move(newchildren);
   for(auto& p: codeid) p.second = grouping[p.second];
   N = nogroups;
   rootid = grouping[rootid];

--- a/irregular.cpp
+++ b/irregular.cpp
@@ -148,7 +148,7 @@ void bitruncate() {
           cells[id].neid[(k+5)%6] = bitruncated_id[make_pair(i, next)];
           }
       }
-    cells[i].neid = move(newnei);
+    cells[i].neid = std::move(newnei);
     }
   make_cells_of_heptagon();
   compute_jpoints();
@@ -241,7 +241,7 @@ bool step(int delta) {
             ld val = hdist(h, relmatrices[p.owner] * p.p);
             if(val < mindist) mindist = val;
             }
-          if(mindist > bestval) bestval = mindist, s.owner = c, s.p = h, s.relmatrices = move(relmatrices);
+          if(mindist > bestval) bestval = mindist, s.owner = c, s.p = h, s.relmatrices = std::move(relmatrices);
           }
         }
       make_cells_of_heptagon();

--- a/mapeditor.cpp
+++ b/mapeditor.cpp
@@ -2371,7 +2371,7 @@ EX namespace mapeditor {
           }
         if(uni == 'c') dsCur->list.push_back(best);
         else if(uni == 'd') {
-          vector<hyperpoint> oldlist = move(dsCur->list);
+          vector<hyperpoint> oldlist = std::move(dsCur->list);
           dsCur->list.clear();
           int i;
           for(i=0; i<isize(oldlist); i+=3)

--- a/multigame.cpp
+++ b/multigame.cpp
@@ -26,25 +26,24 @@ struct gamedata {
     if(ssize & 7) ssize = (ssize | 7) + 1;
     if(mode == 0) {
       record.resize(index+ssize);
-      T& at = *(new (&record[index]) T());
-      at = move(x);
+      ::new (&record[index]) T(std::move(x));
       }
     else {
       T& at = (T&) record[index];
-      x = move(at);
+      x = std::move(at);
       at.~T();
       }
     index += ssize;
     }
   template<class T> void store_ptr(T& x) {
-    T* copy;
     if(mode == 0) {
-      copy = new T;
-      *copy = move(x);
+      T* copy = new T(std::move(x));
+      store(copy);
       }
-    store(copy);
-    if(mode != 0) {
-      x = move(*copy);
+    else {
+      T* copy = nullptr;
+      store(copy);
+      x = std::move(*copy);
       delete copy;
       }
     }

--- a/nonisotropic.cpp
+++ b/nonisotropic.cpp
@@ -88,11 +88,11 @@ EX namespace sn {
     FILE *f = fopen(fname.c_str(), "rb");
     if(!f) f = fopen((rsrcdir + fname).c_str(), "rb");
     if(!f) { addMessage(XLAT("geodesic table missing")); pmodel = mdPerspective; return; }
-    ignore(fread(&PRECX, 4, 1, f));
-    ignore(fread(&PRECY, 4, 1, f));
-    ignore(fread(&PRECZ, 4, 1, f));
+    hr::ignore(fread(&PRECX, 4, 1, f));
+    hr::ignore(fread(&PRECY, 4, 1, f));
+    hr::ignore(fread(&PRECZ, 4, 1, f));
     tab.resize(PRECX * PRECY * PRECZ);
-    ignore(fread(&tab[0], sizeof(compressed_point) * PRECX * PRECY * PRECZ, 1, f));
+    hr::ignore(fread(&tab[0], sizeof(compressed_point) * PRECX * PRECY * PRECZ, 1, f));
     fclose(f);
     loaded = true;    
     }

--- a/reg3.cpp
+++ b/reg3.cpp
@@ -1231,7 +1231,7 @@ EX namespace reg3 {
               nb.insert(v - by * (v[index] / by[index]));
             else println(hlog, "error");    
           
-          boundaries = move(nb);
+          boundaries = std::move(nb);
           break;
           }
         }

--- a/rogueviz/banachtarski.cpp
+++ b/rogueviz/banachtarski.cpp
@@ -389,17 +389,17 @@ void bantar_frame() {
     drawthemap();
     if(0) for(auto p: parent) if(gmatrix.count(p.first) && gmatrix.count(p.second) && infos[p.first].gid == i && infos[p.second].gid == i)
       queueline(tC0(gmatrix[p.first]), tC0(gmatrix[p.second]), 0xFFFFFFFF, 2);
-    subscr[i] = move(ptds);
+    subscr[i] = std::move(ptds);
     }
   
   map<int, map<int, vector<unique_ptr<drawqueueitem>>>> xptds;
   for(int i=0; i<4; i++) for(auto& p: subscr[i])
-    xptds[int(p->prio)][i].push_back(move(p));
+    xptds[int(p->prio)][i].push_back(std::move(p));
 
   for(auto& sm: xptds) for(auto& sm2: sm.second) {
     int i = sm2.first;
     ptds.clear();
-    for(auto& p: sm2.second) ptds.push_back(move(p));
+    for(auto& p: sm2.second) ptds.push_back(std::move(p));
 
     pconf.scale = .5;
     pconf.xposition = (!(i&2)) ? xdst : -xdst;

--- a/rogueviz/dynamic-wfc.cpp
+++ b/rogueviz/dynamic-wfc.cpp
@@ -313,7 +313,7 @@ void wfc() {
       nfreq.emplace_back(p);
       nfreq.back().code |= (code_t(c) << sh);
       }
-    freq = move(nfreq);
+    freq = std::move(nfreq);
     nfreq = {};
     // println(hlog, "inpath = ", inpath);
     // println(hlog, "freqs = ", isize(freq));

--- a/rogueviz/gobot.cpp
+++ b/rogueviz/gobot.cpp
@@ -157,8 +157,8 @@ void clean_old_shots() {
        sh.get().delete_message();
       }
     else
-      remaining.emplace_back(move(sh));
-  old_shots = move(remaining);
+      remaining.emplace_back(std::move(sh));
+  old_shots = std::move(remaining);
   */
   }
 

--- a/rogueviz/gobot.cpp
+++ b/rogueviz/gobot.cpp
@@ -610,8 +610,7 @@ auto gobot_hook =
       shot_state = 2;
       }
     return false;
-    });
-    
+    })
   ;
   
 #endif

--- a/rogueviz/gobot.cpp
+++ b/rogueviz/gobot.cpp
@@ -533,10 +533,9 @@ void go_menu() {
     else if(current.owner[i] != Free)
       owned_by[current.owner[i]]++;
     
-    shstream ss;
-    println(ss, "black: ", stones[0], " stones, ", owned_by[0], " area, ", current.captures[1], " prisoners");
-    println(ss, "white: ", stones[1], " stones, ", owned_by[1], " area, ", current.captures[0], " prisoners");
-
+  shstream ss;
+  println(ss, "black: ", stones[0], " stones, ", owned_by[0], " area, ", current.captures[1], " prisoners");
+  println(ss, "white: ", stones[1], " stones, ", owned_by[1], " area, ", current.captures[0], " prisoners");
 
   dialog::addSelItem("play black", its(stones[0]), 'b');
   dialog::add_action([] { try_to_play(mouse_label(), 0); });

--- a/rogueviz/nil-compass.cpp
+++ b/rogueviz/nil-compass.cpp
@@ -90,22 +90,22 @@ bool draw_compass(cell *c, const shiftmatrix& V) {
     }
 
   poly_outline = 0;
-  for(auto& [col, i, is, sh]: shapes) {
+  for(const auto& s: shapes) {
 
     ld t = 36 + (ticks - zeroticks) / 1000.;
     
     auto remap = [&] (int _i, int _is) {
-      if(i == _i && is == _is) return col;
-      int c = part(col, 1) + part(col, 2) + part(col, 3);
+      if(s.i == _i && s.is == _is) return col;
+      int c = part(s.col, 1) + part(s.col, 2) + part(s.col, 3);
       c += 1; c /= 12;
-      color_t col1 = col;
+      color_t col1 = s.col;
       part(col1, 1) = part(col1, 2) = part(col1, 3) = c;
-      return gradient(col, col1, 0, 0.9, 1);
+      return gradient(s.col, col1, 0, 0.9, 1);
       };
     
     vector<pair<ld, color_t>> clist = {
-      {36, col},
-      {42.5, col},
+      {36, s.col},
+      {42.5, s.col},
       {42.7, remap(1, -1)},
       {43.9, remap(1, -1)},
       {44.1, remap(0, +1)},
@@ -118,8 +118,8 @@ bool draw_compass(cell *c, const shiftmatrix& V) {
       {48.1, remap(2, -1)},
       {48.3, remap(2, +1)},
       {49.1, remap(2, +1)},
-      {49.3, col},
-      {99, col}
+      {49.3, s.col},
+      {99, s.col}
       };
     
     int step = 0;
@@ -128,7 +128,7 @@ bool draw_compass(cell *c, const shiftmatrix& V) {
     auto t1 = ilerp(clist[step].first, clist[step+1].first, t);
     auto col1 = gradient(clist[step].second, clist[step+1].second, 0, smoothen(t1), 1);
     
-    queuepoly(V, sh, col1);
+    queuepoly(V, s.sh, col1);
     }
 
   return false;

--- a/rogueviz/presentation.cpp
+++ b/rogueviz/presentation.cpp
@@ -542,9 +542,8 @@ int runslide = arg::add3("-slides", [] {
   + arg::add3("-presangle", [] {
     arg::shift_arg_formula(angle);
     dir = 0;
-    });
+    })
   ;
-
 }
 #endif
 }

--- a/rogueviz/presentation.cpp
+++ b/rogueviz/presentation.cpp
@@ -160,7 +160,7 @@ string gen_latex(presmode mode, string s, int res) {
   string filename = format("latex-cache/%08X.png", hash);
   if(mode == pmStartAll) {
     if(!file_exists(filename)) {
-      system("mkdir latex-cache");
+      hr::ignore(system("mkdir latex-cache"));
       FILE *f = fopen("latex-cache/rogueviz-latex.tex", "w");
       fprintf(f,
         "\\documentclass[border=2pt]{standalone}\n"
@@ -172,9 +172,9 @@ string gen_latex(presmode mode, string s, int res) {
         "\\end{varwidth}\n"
         "\\end{document}\n", s.c_str());
       fclose(f);
-      system("cd latex-cache; pdflatex rogueviz-latex.tex");
+      hr::ignore(system("cd latex-cache; pdflatex rogueviz-latex.tex"));
       string pngline = "cd latex-cache; pdftopng -r " + its(res) + " rogueviz-latex.pdf t";
-      system(pngline.c_str());
+      hr::ignore(system(pngline.c_str()));
       rename("latex-cache/t-000001.png", filename.c_str());
       }
     }

--- a/rogueviz/rewriting.cpp
+++ b/rogueviz/rewriting.cpp
@@ -39,7 +39,7 @@ struct hrmap_rewrite : hrmap_hyperbolic {
   map<heptagon*, pair<heptagon*, string> > asg;
   map<pair<heptagon*, string>, heptagon*> asg_rev;
 
-  heptagon *create_step(heptagon *h, int direction) {
+  heptagon *create_step(heptagon *h, int direction) override {
     if(h->move(direction)) return h->move(direction);
     if(asg.empty()) { asg[h] = {h, start}; h->zebraval = 0; }
     

--- a/rogueviz/som/analyzer.cpp
+++ b/rogueviz/som/analyzer.cpp
@@ -36,13 +36,13 @@ void load_maniset(maniset& m, int scale) {
       m.names.push_back(buf);
     auto& md = m.mdata[buf];
     int N, M;
-    fscanf(f, "%d%d", &N, &M);
+    hr::ignore(fscanf(f, "%d%d", &N, &M));
     println(hlog, "reading ", buf, " of size ", N, " and ", M, " edges");
     md.size = N;
     auto& ed = md.edges;
     for(int i=0; i<M; i++) {
       int a, b;
-      fscanf(f, "%d%d", &a, &b);
+      hr::ignore(fscanf(f, "%d%d", &a, &b));
       ed.emplace_back(a, b);
       }
     md.distances = measures::build_distance_matrix(N, md.edges);
@@ -125,10 +125,10 @@ void analyze_test() {
 
             while(current_row < it) {
               current_row++;
-              for(int i=0; i<No; i++) fscanf(f, "%d", &mapp[i]);
-              int V = 0; fscanf(vor, "%d", &V);
+              for(int i=0; i<No; i++) hr::ignore(fscanf(f, "%d", &mapp[i]));
+              int V = 0; hr::ignore(fscanf(vor, "%d", &V));
               vor_edges.resize(V);
-              for(int i=0; i<V; i++) fscanf(vor, "%d%d", &vor_edges[i].first, &vor_edges[i].second);
+              for(int i=0; i<V; i++) hr::ignore(fscanf(vor, "%d%d", &vor_edges[i].first, &vor_edges[i].second));
               if(mapp.back() == -2) goto next_pair;
               if(current_row == it)
                 edo_recreated = measures::recreate_topology(mapp, edo);

--- a/rogueviz/som/kohonen.cpp
+++ b/rogueviz/som/kohonen.cpp
@@ -91,7 +91,7 @@ void loadsamples(const string& fname) {
       if(c == '!' && s.name == "") shown = true;
       else if(!rv_ignore(c)) s.name += c;
       }
-    data.push_back(move(s));
+    data.push_back(std::move(s));
     if(shown) 
       samples_to_show.push_back(isize(data)-1);
     }
@@ -624,7 +624,7 @@ void verify_crawlers() {
       breakcheck:
       cellcrawler cr;
       cr.build(cellwalker(c, id.second));
-      allcrawlers[id.first] = move(cr);
+      allcrawlers[id.first] = std::move(cr);
       uniq++;
       }
     }

--- a/rogueviz/som/tests.cpp
+++ b/rogueviz/som/tests.cpp
@@ -800,7 +800,7 @@ bool more = true;
 
 void create_index() {
 
-  system(("mkdir " + som_test_dir).c_str());
+  hr::ignore(system(("mkdir " + som_test_dir).c_str()));
 
   fhstream f(som_test_dir + "index-" + its(current_scale) + ".html", "wt");
 
@@ -958,7 +958,7 @@ void all_pairs(bool one) {
 
   string dir = som_test_dir + "pairs" + cg();
 
-  system(("mkdir -p " + dir + "/img").c_str());  
+  hr::ignore(system(("mkdir -p " + dir + "/img").c_str()));
 
   int sid = 0;
   for(auto s1: shapelist) {
@@ -1093,7 +1093,7 @@ void all_pairs(bool one) {
       }
     }
 
-  system("touch done");  
+  hr::ignore(system("touch done"));
   }
 
 bool verify_distlists = false;

--- a/rogueviz/som/tests.cpp
+++ b/rogueviz/som/tests.cpp
@@ -97,7 +97,7 @@ void create_data() {
     where.push_back(c);
     sample s;
     embeddings::get_coordinates(s.val, c, c0);
-    data.push_back(move(s));
+    data.push_back(std::move(s));
     }
   samples = isize(data);
   test_orig.size = samples;

--- a/surface.cpp
+++ b/surface.cpp
@@ -480,8 +480,8 @@ void run_kuen() {
   int it = 0;
   for(auto p: rug::points) p->dexp_id = it++;
   
-  vector<rug::rugpoint*> mesh = move(rug::points);
-  vector<rug::triangle> old_triangles = move(rug::triangles);
+  vector<rug::rugpoint*> mesh = std::move(rug::points);
+  vector<rug::triangle> old_triangles = std::move(rug::triangles);
   
   rug::clear_model();
   

--- a/textures.cpp
+++ b/textures.cpp
@@ -979,7 +979,7 @@ string tes;
 
 void init_textureconfig() {
 #if CAP_CONFIG
-  texturesavers = move(savers);  
+  texturesavers = std::move(savers);  
   for(int i=0; i<3; i++)
   for(int j=0; j<3; j++)
     addsaver(config.itt[i][j], "texturematrix_" + its(i) + its(j), i==j ? 1 : 0);
@@ -1131,10 +1131,10 @@ bool texture_config::load() {
   models::configure();
   drawthemap();
   config.tstate = config.tstate_max = tsActive;
-  string s = move(texture_tuner);
+  string s = std::move(texture_tuner);
   perform_mapping();
   
-  texture_tuner = move(s);
+  texture_tuner = std::move(s);
   
   if(texture_tuner != "") {
     texture_tuned = true;
@@ -1665,7 +1665,7 @@ void texture_config::true_remap() {
       if(GOLDBERG || IRREGULAR) pshift += si.dir;
       mapTexture(c, mi2, si, ggmatrix(c), pshift);
       mapTexture2(mi2);
-      mi2.tvertices = move(new_tvertices);
+      mi2.tvertices = std::move(new_tvertices);
       // printf("%08x remapping %d vertices to %d vertices\n", si.id, isize(mi.tvertices), isize(mi2.tvertices));
       }
     catch(out_of_range&) { 


### PR DESCRIPTION
I haven't yet figured out where [this warning](https://github.com/zenorogue/hyperrogue/runs/7198003805?check_suite_focus=true) is coming from:
```
In file included from rogueviz/rogueviz-all.cpp:21,
                 from hyper.cpp:128:
rogueviz/qtm.cpp:217:15: error: embedding a directive within macro arguments is not portable [-Werror]
  217 |               #if CAP_RAY
      |               ^
```

Here are the warnings I still see, after this patch series, when I build locally with top-of-tree Clang:
```
clang++ -O2 -std=c++11 -Wembedded-directive -DMAC -I/usr/local/include -fPIC -W -Wall -Wextra -Wsuggest-override -pedantic -Wno-unused-parameter -Wno-implicit-fallthrough -Wno-maybe-uninitialized -Wno-char-subscripts -Wno-unknown-warning-option -Wno-invalid-offsetof -DCAP_GLEW=0 -DCAP_PNG=0    -c hyper.cpp -o hyper.o
In file included from hyper.cpp:47:
./crystal.cpp:856:7: warning: variable 'steps' set but not used [-Wunused-but-set-variable]
  int steps = 0;
      ^
In file included from hyper.cpp:82:
In file included from ./3d-models.cpp:9:
./earcut.hpp:283:9: warning: variable 'iterations' set but not used [-Wunused-but-set-variable]
    int iterations = 0;
        ^
In file included from hyper.cpp:82:
./3d-models.cpp:530:7: warning: variable 'it' set but not used [-Wunused-but-set-variable]
  int it = 0;
      ^
./3d-models.cpp:745:16: warning: variable 'qtyall' set but not used [-Wunused-but-set-variable]
  int qty = 0, qtyall = 0;
               ^
In file included from hyper.cpp:85:
./drawing.cpp:1417:11: warning: variable 'ia' set but not used [-Wunused-but-set-variable]
      int ia = 0, ib = 0, ic = 0;
          ^
./drawing.cpp:1417:19: warning: variable 'ib' set but not used [-Wunused-but-set-variable]
      int ia = 0, ib = 0, ic = 0;
                  ^
./drawing.cpp:1417:27: warning: variable 'ic' set but not used [-Wunused-but-set-variable]
      int ia = 0, ib = 0, ic = 0;
                          ^
In file included from hyper.cpp:117:
./barriers.cpp:980:7: warning: variable 'a0' set but not used [-Wunused-but-set-variable]
  int a0 = 0;
      ^
In file included from hyper.cpp:118:
./surface.cpp:194:10: warning: use of bitwise '&' with boolean operands [-Wbitwise-instead-of-logical]
  return flag_clamp_min(coord, minv) & flag_clamp_max(coord, maxv);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                     &&
./surface.cpp:194:10: note: cast one or both operands to int to silence this warning
./surface.cpp:212:14: warning: use of bitwise '&' with boolean operands [-Wbitwise-instead-of-logical]
      return flag_clamp_min(x, 0) & flag_clamp_sym(y, M_PI);
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                  &&
./surface.cpp:212:14: note: cast one or both operands to int to silence this warning
./surface.cpp:215:14: warning: use of bitwise '&' with boolean operands [-Wbitwise-instead-of-logical]
      return flag_clamp(x, 0, M_PI) & flag_clamp(y, 0, 2*M_PI);
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                    &&
./surface.cpp:215:14: note: cast one or both operands to int to silence this warning
./surface.cpp:218:14: warning: use of bitwise '&' with boolean operands [-Wbitwise-instead-of-logical]
      return flag_clamp_sym(x, M_PI) & flag_clamp_sym(y, hyperlike_bound());
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                     &&
./surface.cpp:218:14: note: cast one or both operands to int to silence this warning
```

