### PR TITLE
Highlight hostile dice if poly_outline is set for highlighting.

### DIFF
--- a/complex2.cpp
+++ b/complex2.cpp
@@ -1393,7 +1393,7 @@ EX namespace dice {
         cy = face[1] - (face[3] + face[4]) * .4;
         }
       
-      queuecurve(V1, 0xFFFFFFFF, color & 0xFFFFFF9F, prio);
+      queuecurve(V1, (poly_outline == OUTLINE_NONE) ? 0xFFFFFFFF : poly_outline, color & 0xFFFFFF9F, prio);
       
       #if !CAP_EXTFONT
       if(!vid.usingGL) continue;


### PR DESCRIPTION
Hostile dice (Animate Dice & Angry Dice) are currently not highlighted when Alt or Alt-8 triggers highlighting enemy creatures.  This fixes that by checking for `poly_outline` being set to a value other than `OUTLINE_NONE` in `draw_dice`.