### PR TITLE
Draw mimics with sword in left hand if PC's sword in left hand.

### DIFF
--- a/graph.cpp
+++ b/graph.cpp
@@ -1512,7 +1512,8 @@ void drawMimic(eMonster m, cell *where, const shiftmatrix& V, color_t col, doubl
       if(items[itOrbSide3] && emp)
         queuepoly(VBODY * VBS, (cs.charid&1) ? cgi.shFerocityF : cgi.shFerocityM, darkena(col, 0, 0x40));
 
-      queuepoly(VBODY * VBS, (cs.charid >= 2 ? cgi.shSabre : cgi.shPSword), darkena(col, 0, 0XC0));
+      shiftmatrix VWPN = cs.lefthanded ? VBODY * VBS * Mirror : VBODY * VBS;
+      queuepoly(VWPN, (cs.charid >= 2 ? cgi.shSabre : cgi.shPSword), darkena(col, 0, 0XC0));
       }
     else if(!where || shmup::curtime >= shmup::getPlayer()->nextshot)
       queuepoly(VBODY * VBS, cgi.shPKnife, darkena(col, 0, 0XC0));


### PR DESCRIPTION
Currently, mimics always have their swords in their right hand, even if the rogue has their sword in the left.  (Interpreting that mirror mimics' left hands appear to us to be the right hand & vice versa.  Under an alternate "WYSIWYG" interpretation, mirror mimics always wield with the left hand and mirage mimics with the right.)

This change flips the mimics' sword hand if the rogue is left-handed.  This way rogue movements with/against the sword hand cause mimic movements that are also with/against their sword hands respectively.