### PR TITLE
OSM: Make the orb quantity in the inventory screen black.

### DIFF
--- a/inventory.cpp
+++ b/inventory.cpp
@@ -547,10 +547,8 @@ EX namespace inv {
                 quickqueue();
                 }
               
-              int tcol = remaining[i] ? darkenedby(icol, 1) : 0;
-  
               if(remaining[i] != 1 || !gg)
-                displaystr(px, py, 2, gg?rad:rad*3/2, remaining[i] <= 0 ? "X" : remaining[i] == 1 ? "o" : its(remaining[i]), tcol, 8);
+                displaystr(px, py, 2, gg?rad:rad*3/2, remaining[i] <= 0 ? "X" : remaining[i] == 1 ? "o" : its(remaining[i]), 0, 8);
               }
             
             bool b = hypot(mousex-px, mousey-py) < rad;


### PR DESCRIPTION
An unintended side effect of the orb icons I created was to reduce the legibility of the orb quantities in OSM, because they also operate by darkening a shape (in this case, a numeral instead of an icon) on the orb's disk.

This aims to fix that problem I introduced by making the number overlay black, which should be a good contrast with any orb.

Before:
![osm_before](https://user-images.githubusercontent.com/501357/201417874-321bbbb7-cd52-4f1d-9ddb-794f1c610e49.png)

After:
![osm_after](https://user-images.githubusercontent.com/501357/201417966-569debfd-18f7-4de3-affa-b64444871b1a.png)
