### PR TITLE
Give the Plane of Fire a redder floor than CR4.

### DIFF
--- a/content.cpp
+++ b/content.cpp
@@ -1256,7 +1256,7 @@ LAND( 0x606060, "Zebra", laZebra, ZERO, itZebra, RESERVED, "Everything in this L
   NATIVE((m == moOrangeDog) ? 2 : 0)
   REQ(GOLD(R30) ITEMS(itFeather, U10))
 
-LAND( 0xC08080, "Plane of Fire", laEFire, ZERO | LF_ELEMENTAL, itElemental, RESERVED, elemdesc)
+LAND( 0xFFA080, "Plane of Fire", laEFire, ZERO | LF_ELEMENTAL, itElemental, RESERVED, elemdesc)
   NATIVE(m == moFireElemental ? 2 : isNative(laElementalWall, m))
   REQAS(laElementalWall,)
 


### PR DESCRIPTION
The absence of contrast between PoF and Crossroads IV was noted by Mark Heptagons in https://discord.com/channels/540092734300618753/550649263772794890/1045093815222018088

Status quo, escher:
![pof_cr4-1](https://user-images.githubusercontent.com/501357/204429686-c0afabd7-ac60-4a97-8210-c1308618a296.png)
Status quo, basic:
![pof_cr4-2](https://user-images.githubusercontent.com/501357/204429799-eb6cfd32-c210-4bcb-a32f-3f46225e4ced.png)

Post, escher:
![pof_cr4-6](https://user-images.githubusercontent.com/501357/204429869-766c9e90-54db-422b-b9ec-a4309b58c5ac.png)
Post, basic:
![pof_cr4-7](https://user-images.githubusercontent.com/501357/204429895-8c61bcf3-96ed-4ccc-9477-0d26b10b2ded.png)

