### PR TITLE
Reset hr::instat in drawStats() if cornermode is enabled.

### DIFF
--- a/hud.cpp
+++ b/hud.cpp
@@ -476,13 +476,13 @@ EX void drawStats() {
     quickqueue();
     }
   
-  if(racing::on) 
+  if(racing::on) {
 #if CAP_RACING
     racing::drawStats();
-#else
-    {}
 #endif
+    }
   else if(cornermode) {
+    instat = false;
     int bycorner[4];
     for(int u=0; u<4; u++) bycorner[u] = 0;
     for(int i=0; i<glyphs; i++) if(ikappear(i) && (glyphflags(i) & GLYPH_INSQUARE))


### PR DESCRIPTION
This appears to fix a bug where the HUD's north-of-map text gets stuck in "Press F1 or right click for help".

To reproduce:
* Narrow the window so that the treasures/monsters/orbs HUD indications switch from two-sides to four-corners.
* Mouse over a monster HUD indicator in the northeast area.
* Mouse over the map.

Expected behavior is that the description text on the HUD's north edge gives descriptions of the land.

The behavior appears to be correct after this is applied, but this is the first time I've investigated the logic setting and resetting `hr::instat`, so I'm not positive that it should always be reset here.
