### PR TITLE
Swap the Red Troll's hair & fur colors.

### DIFF
--- a/graph.cpp
+++ b/graph.cpp
@@ -2399,8 +2399,8 @@ EX bool drawMonsterType(eMonster m, cell *where, const shiftmatrix& V1, color_t 
     case moRedTroll: {
       const shiftmatrix VBS = VBODY * otherbodyparts(V, darkena(col, 0, 0xFF), m, footphase);
       ShadowV(V, cgi.shYeti);
-      queuepoly(VBS, cgi.shYeti, darkena(col, 0, 0xC0));
-      queuepoly(VHEAD1, cgi.shPHead, darkena(0xFF8000, 0, 0XFF));
+      queuepoly(VBS, cgi.shYeti, darkena(0xFF8000, 0, 0XFF));
+      queuepoly(VHEAD1, cgi.shPHead, darkena(col, 0, 0xC0));
       queuepoly(VHEAD, cgi.shPFace, 0xFFFFFF80 | UNTRANS);
       humanoid_eyes(V, 0x000000FF, darkena(col, 0, 0xFF));
       return true;


### PR DESCRIPTION
Red Trolls have low contrast with the floor and platforms of their native Red Rock Valley.  Swapping the colors of their body and mane makes them stand out better.

Left is current coloration, right is new coloration.  Upper is normal display, lower is highlighted.
![rtroll2x2](https://user-images.githubusercontent.com/501357/227350905-3f0565f5-f7fd-40d0-b04a-bf65dc5ea8a1.png)
