### PR TITLE
Avoid sprintf, in favor of hr::format and snprintf

### DIFF
--- a/archimedean.cpp
+++ b/archimedean.cpp
@@ -291,7 +291,7 @@ void archimedean_tiling::prepare() {
       int inv = oi;
       DEBB0(DF_GEOM, ("vertex "));
       for(int z=0; z<faces[i]; z++) {
-        DEBB0(DF_GEOM, (format("[%d %d] " , at, inv)));
+        DEBB0(DF_GEOM, (hr::format("[%d %d] " , at, inv)));
         adjacent[2*i+oi].emplace_back(2*N+int(inv), inv ? (2*at+2*N-2) % (2*N) : 2*at);
         if(invert[at]) inv ^= 1;
         at = adj[at];
@@ -299,7 +299,7 @@ void archimedean_tiling::prepare() {
         else at = (at+N-1) % N;
         }
       if(!inv) make_match(2*i, 0, inv ? (2*at+2*N-1) % 2*N : 2*at, 0);
-      DEBB(DF_GEOM, (format("-> [%d %d]\n", at, inv)));
+      DEBB(DF_GEOM, (hr::format("-> [%d %d]\n", at, inv)));
       }
     }
   for(int i=0; i<N; i++) {
@@ -348,11 +348,11 @@ void archimedean_tiling::prepare() {
       int ai = i, aj = j;
       DEBB0(DF_GEOM, ("triangle "));
       for(int s=0; s<3; s++) {
-        DEBB0(DF_GEOM, (format("[%d %d] ", ai, aj)));
+        DEBB0(DF_GEOM, (hr::format("[%d %d] ", ai, aj)));
         tie(ai, aj) = adjacent[ai][aj];
         aj++; if(aj >= isize(adjacent[ai])) aj = 0;
         }
-      DEBB(DF_GEOM, (format("-> [%d %d]\n", ai, aj)));
+      DEBB(DF_GEOM, (hr::format("-> [%d %d]\n", ai, aj)));
       make_match(i, j, ai, aj);
       }
     }
@@ -406,7 +406,7 @@ void archimedean_tiling::regroup() {
   
   if(debugflags & DF_GEOM) {
     for(int i=0; i<M; i+=(have_symmetry?1:2)) {
-      DEBB(DF_GEOM, (format("tiling group of %2d: [%2d]%2d+Z%2d\n", i, tilegroup[i], groupoffset[i], periods[i])));
+      DEBB(DF_GEOM, (hr::format("tiling group of %2d: [%2d]%2d+Z%2d\n", i, tilegroup[i], groupoffset[i], periods[i])));
       }
     }
   }
@@ -433,7 +433,7 @@ void archimedean_tiling::compute_geometry() {
     set_flag(arr[gArchimedean].flags, qCLOSED, gg.kind == gcSphere);
     }
 
-  DEBB(DF_GEOM, (format("euclidean_angle_sum = %f\n", float(euclidean_angle_sum))));
+  DEBB(DF_GEOM, (hr::format("euclidean_angle_sum = %f\n", float(euclidean_angle_sum))));
 
   bool infake = fake::in();
   
@@ -515,7 +515,7 @@ void archimedean_tiling::compute_geometry() {
 
   if(need_flip) geom3::light_flip(false);
   
-  DEBB(DF_GEOM, (format("computed edgelength = %f\n", float(edgelength))));
+  DEBB(DF_GEOM, (hr::format("computed edgelength = %f\n", float(edgelength))));
   
   triangles.clear();
   triangles.resize(2*N+2);
@@ -537,7 +537,7 @@ void archimedean_tiling::compute_geometry() {
 
   if(debugflags & DF_GEOM) for(auto& ts: triangles) {
     DEBB0(DF_GEOM, ("T"));
-    for(auto& t: ts) DEBB0(DF_GEOM, (format(" %f@%f", float(t.first), float(t.second))));
+    for(auto& t: ts) DEBB0(DF_GEOM, (hr::format(" %f@%f", float(t.first), float(t.second))));
     DEBB(DF_GEOM, ());
     }
 
@@ -937,7 +937,7 @@ void connect_digons_too(heptspin h1, heptspin h2) {
     // no need to specify archimedean_gmatrix and altmap
     hnew->c.connect(1, h2);
     h1--, h2++;
-    DEBB(DF_GEOM, (format("OL2 %p.%d ~ %p.%d\n", hr::voidp(h1.at), h1.spin, hr::voidp(h2.at), h2.spin)));
+    DEBB(DF_GEOM, (hr::format("OL2 %p.%d ~ %p.%d\n", hr::voidp(h1.at), h1.spin, hr::voidp(h2.at), h2.spin)));
     h1.at->c.connect(h1.spin, h2);
     }
   }
@@ -945,15 +945,15 @@ void connect_digons_too(heptspin h1, heptspin h2) {
 void connectHeptagons(heptspin hi, heptspin hs) {
   DEBB(DF_GEOM, ("OLD ", hi, " ~ ", hs));
   if(hi.at->move(hi.spin) == hs.at && hi.at->c.spin(hi.spin) == hs.spin) {
-    DEBB(DF_GEOM, (format("WARNING: already connected\n")));
+    DEBB(DF_GEOM, (hr::format("WARNING: already connected\n")));
     return;
     }
   if(hi.peek()) {
-    DEBB(DF_GEOM, (format("ERROR: already connected left\n")));
+    DEBB(DF_GEOM, (hr::format("ERROR: already connected left\n")));
     throw hr_archimedean_error("Archimedean error: already connected left");
     }
   if(hs.peek()) {
-    DEBB(DF_GEOM, (format("ERROR: already connected right\n")));
+    DEBB(DF_GEOM, (hr::format("ERROR: already connected right\n")));
     throw hr_archimedean_error("Archimedean error: already connected right");
     }
   hi.at->c.connect(hi.spin, hs);

--- a/cell.cpp
+++ b/cell.cpp
@@ -607,17 +607,17 @@ EX void initcells() {
 
 EX void clearcell(cell *c) {
   if(!c) return;
-  DEBB(DF_MEMORY, (format("c%d %p\n", c->type, hr::voidp(c))));
+  DEBB(DF_MEMORY, (hr::format("c%d %p\n", c->type, hr::voidp(c))));
   for(int t=0; t<c->type; t++) if(c->move(t)) {
-    DEBB(DF_MEMORY, (format("mov %p [%p] S%d\n", hr::voidp(c->move(t)), hr::voidp(c->move(t)->move(c->c.spin(t))), c->c.spin(t))));
+    DEBB(DF_MEMORY, (hr::format("mov %p [%p] S%d\n", hr::voidp(c->move(t)), hr::voidp(c->move(t)->move(c->c.spin(t))), c->c.spin(t))));
     if(c->move(t)->move(c->c.spin(t)) != NULL &&
       c->move(t)->move(c->c.spin(t)) != c) {
-        DEBB(DF_MEMORY | DF_ERROR, (format("cell error: type = %d %d -> %d\n", c->type, t, c->c.spin(t))));
+        DEBB(DF_MEMORY | DF_ERROR, (hr::format("cell error: type = %d %d -> %d\n", c->type, t, c->c.spin(t))));
         if(worst_precision_error < 1e-3) exit(1);
         }
     c->move(t)->move(c->c.spin(t)) = NULL;
     }
-  DEBB(DF_MEMORY, (format("DEL %p\n", hr::voidp(c))));
+  DEBB(DF_MEMORY, (hr::format("DEL %p\n", hr::voidp(c))));
   gp::delete_mapped(c);
   destroy_cell(c);
   }

--- a/config.cpp
+++ b/config.cpp
@@ -1943,7 +1943,7 @@ EX void menuitem_sightrange(char c IS('c')) {
   else if(WDIM == 3)
     dialog::addSelItem(XLAT("sight range settings"), fts(sightranges[geometry]) + "au", c);
   else
-    dialog::addSelItem(XLAT("sight range settings"), format("%+d", sightrange_bonus), c);
+    dialog::addSelItem(XLAT("sight range settings"), hr::format("%+d", sightrange_bonus), c);
   dialog::add_action_push(edit_sightrange);
   }
 

--- a/crystal.cpp
+++ b/crystal.cpp
@@ -1318,9 +1318,7 @@ EX void set_crystal(int sides) {
   set_variation(eVariation::pure);
   ginf[gCrystal].sides = sides;
   ginf[gCrystal].vertex = 4;
-  static char buf[20];
-  sprintf(buf, "{%d,4}", sides);
-  ginf[gCrystal].tiling_name = buf;
+  ginf[gCrystal].tiling_name = hr::format("{%d,4}", sides);
   ginf[gCrystal].distlimit = distlimit_table[min(sides, MAX_EDGE_CRYSTAL-1)];
   }
 

--- a/crystal.cpp
+++ b/crystal.cpp
@@ -1562,7 +1562,7 @@ struct shift_data {
   
   bignum& compute(ld rad2) {
     if(result.count(rad2)) return result[rad2];
-    // println(hlog, "compute ", format("%p", this), " [shift=", shift, "], r2 = ", rad2);
+    // println(hlog, "compute ", hr::format("%p", this), " [shift=", shift, "], r2 = ", rad2);
     // indenter i(2);
     auto& b = result[rad2];
     if(!parent) {

--- a/debug.cpp
+++ b/debug.cpp
@@ -308,8 +308,6 @@ struct debugScreen {
       #if CAP_SHAPES
       queuepoly(gmatrix[what], cgi.shAsymmetric, 0x80808080);
       #endif
-      char buf[200];
-      sprintf(buf, "%p", hr::voidp(what));
       dialog::addSelItem("mpdist", its(what->mpdist), 'd');
       dialog::add_action([what] () { 
         bitfield_editor(what->mpdist, [what] (int i) { what->mpdist = 0; }, "generation level");        
@@ -390,7 +388,7 @@ struct debugScreen {
       dialog::addBreak(50);
       
       if(show_debug_data) {
-        dialog::addSelItem("pointer", s0+buf+"/"+index_pointer(what), 0);
+        dialog::addSelItem("pointer", s0+hr::format("%p", hr::voidp(what))+"/"+index_pointer(what), 0);
         dialog::addSelItem("cpdist", its(what->cpdist), 0);
         dialog::addSelItem("celldist", its(celldist(what)), 0);
         dialog::addSelItem("celldistance", its(celldistance(cwt.at, what)), 0);

--- a/devmods/hatter.cpp
+++ b/devmods/hatter.cpp
@@ -103,11 +103,11 @@ void init() {
   for(int a=0; a<100; a++) {
     ld nq7 = q7 + q8;
     ld nq8 = q7 * 5 + q8 * 6;
-    println(hlog, format("%.20f", val = (nq7 + nq8) / (q7 + q8)));
+    println(hlog, hr::format("%.20f", val = (nq7 + nq8) / (q7 + q8)));
     q7 = nq7; q8 = nq8;
     }
   val = sqrt(val);
-  println(hlog, "root: ", format("%.20f", val));
+  println(hlog, "root: ", hr::format("%.20f", val));
   for(int a=-50; a<50; a++)
   for(int b=1; b<50; b++)
   for(int c=-50; c<50; c++)
@@ -283,7 +283,7 @@ string matcode(transmatrix T) {
   swap(h[1], h[2]); swap(h[0], h[1]);
   // return lalign(0, h);
 
-  return format("R%dA%03dL%.3f", ialpha/60, hangle, hypot_d(2, h));
+  return hr::format("R%dA%03dL%.3f", ialpha/60, hangle, hypot_d(2, h));
   }
 
 int ghatid(string s) {
@@ -431,7 +431,7 @@ void hatframe() {
   }
 
 string writematrix(transmatrix T) {
-  return format("mt(%.10f,%.10f,%.10f, %.10f,%.10f,%.10f, %.10f,%.10f,%.10f)",
+  return hr::format("mt(%.10f,%.10f,%.10f, %.10f,%.10f,%.10f, %.10f,%.10f,%.10f)",
     T[0][0], 
     T[0][1], 
     T[0][2], 
@@ -456,7 +456,7 @@ void hatter() {
   dialog::add_key_action('a', [] {
     hatcorners_add.push_back(sh);
     println(hlog, "hatcorners = {");
-    for(auto h: hatcorners_add) println(hlog, format("  pt(%.10f,%.10f),", h[0], h[1]));
+    for(auto h: hatcorners_add) println(hlog, hr::format("  pt(%.10f,%.10f),", h[0], h[1]));
     println(hlog, "  }");
     });
 

--- a/devmods/manual-animation.cpp
+++ b/devmods/manual-animation.cpp
@@ -379,7 +379,7 @@ void do_recording() {
       ticks = i * 1000 / mrec_fps;
       
       if(i >= mrec_first && i < mrec_last) {
-        string s = format(mrec_file.c_str(), i);
+        string s = hr::format(mrec_file.c_str(), i);
         println(hlog, "recording frame ", i, "/", isize(saved), " to ", s);
         shot::take(s);
         }

--- a/devmods/rulegen-tests.cpp
+++ b/devmods/rulegen-tests.cpp
@@ -1079,7 +1079,7 @@ void test_current(string tesname) {
     case 'O': Out("overts;oedges", lalign(0, count_vertex_orbits(), ";", count_edge_orbits()));
     case 'U': Out("vshapes;vverts;vedges;ushapes;uverts;uedges;xea;xeb;xec", count_uniform());
     case 'L': Out("mirror_rules", arb::current.mirror_rules);
-    case 'B': Out("listshape;listvalence", format("%lld;%lld", get_shapelist(), get_valence_list()));
+    case 'B': Out("listshape;listvalence", hr::format("%lld;%lld", get_shapelist(), get_valence_list()));
     case 'F': Out("maxdist", max_dist());
 
     case 'f': Out("file", tesname);
@@ -1091,7 +1091,7 @@ void test_current(string tesname) {
     case '1': Out("single", single_live_branches);
     case '2': Out("double", double_live_branches);
     case 'p': Out("premini", states_premini);
-    case 'K': Out("movecount", format("%ld", rulegen::movecount));
+    case 'K': Out("movecount", hr::format("%ld", rulegen::movecount));
     }
   println(*test_out);
   test_out->flush();

--- a/devmods/solv-table.cpp
+++ b/devmods/solv-table.cpp
@@ -235,11 +235,11 @@ void build_sols(int PRECX, int PRECY, int PRECZ) {
       auto xerr = solerror(v, nisot::numerical_exp(cand));
       
       if(cand == fail) {
-        println(hlog, format("[%2d %2d %2d] FAIL", iz, iy, ix));
+        println(hlog, hr::format("[%2d %2d %2d] FAIL", iz, iy, ix));
         }
       
       else if(xerr > 1e-3) {
-        println(hlog, format("[%2d %2d %2d] ", iz, iy, ix));
+        println(hlog, hr::format("[%2d %2d %2d] ", iz, iy, ix));
         println(hlog, "f(?) = ", v);
         println(hlog, "f(", cand, ") = ", nisot::numerical_exp(cand));
         println(hlog, "error = ", xerr);
@@ -265,7 +265,7 @@ void build_sols(int PRECX, int PRECY, int PRECZ) {
         }
       if(it < last_x && it < last_y) solve_at(it, it);
       std::lock_guard<std::mutex> fm(file_mutex);
-      if(0) println(hlog, format("%2d: %2d", iz, it));
+      if(0) println(hlog, hr::format("%2d: %2d", iz, it));
       }
     };
 
@@ -469,7 +469,7 @@ void visualize_table(sn::tabled_inverses& tab, const string& s) {
         for(int i=0; i<3; i++)
           part(p, i) = 0x80 + 0x70 * tab.get_int(ix, iy, iz)[i];
         }
-    SDL_SavePNG(rb.srf, format(s.c_str(), iz).c_str());
+    SDL_SavePNG(rb.srf, hr::format(s.c_str(), iz).c_str());
     }
   }
 

--- a/dialogs.cpp
+++ b/dialogs.cpp
@@ -1123,7 +1123,7 @@ EX namespace dialog {
         getcstat = 'A' + i, inslider = true, slider_x = mousex;
       }
     
-    displayColorButton(dcenter, vid.yres/2+vid.fsize * 6, XLAT("select this color") + " : " + format(colorAlpha ? "%08X" : "%06X", color), ' ', 8, 0, color >> (colorAlpha ? ash : 0));
+    displayColorButton(dcenter, vid.yres/2+vid.fsize * 6, XLAT("select this color") + " : " + hr::format(colorAlpha ? "%08X" : "%06X", color), ' ', 8, 0, color >> (colorAlpha ? ash : 0));
 
     if(extra_options) extra_options();
     

--- a/floorshapes.cpp
+++ b/floorshapes.cpp
@@ -1000,7 +1000,7 @@ EX namespace gp {
     bool master = !(li.relative.first||li.relative.second);
     int cor = master ? S7 : SG6;
     if(master) li.last_dir = -1;
-    DEBB(DF_GP, (format("last=%d at=%d,%d tot=%d siid=%d sidir=%d cor=%d id=%d\n", li.last_dir, li.relative.first, li.relative.second, li.total_dir, siid, sidir, cor, id)));
+    DEBB(DF_GP, (hr::format("last=%d at=%d,%d tot=%d siid=%d sidir=%d cor=%d id=%d\n", li.last_dir, li.relative.first, li.relative.second, li.total_dir, siid, sidir, cor, id)));
       
     cgi.generate_floorshapes_for(id, c0, siid, sidir);
     

--- a/geometry.cpp
+++ b/geometry.cpp
@@ -695,7 +695,7 @@ void geometry_information::prepare_basics() {
     : hdist(xpush0(crossf), xspinpush0(TAU/S7, crossf));
   
   DEBB(DF_GEOM | DF_POLY,
-    (format("S7=%d S6=%d hexf = " LDF" hcross = " LDF" tessf = " LDF" hexshift = " LDF " hexhex = " LDF " hexv = " LDF "\n", S7, S6, hexf, hcrossf, tessf, hexshift, 
+    (hr::format("S7=%d S6=%d hexf = " LDF" hcross = " LDF" tessf = " LDF" hexshift = " LDF " hexhex = " LDF " hexv = " LDF "\n", S7, S6, hexf, hcrossf, tessf, hexshift, 
     hexhexdist, hexvdist)));  
   
   base_distlimit = ginf[geometry].distlimit[!BITRUNCATED];

--- a/glhr.cpp
+++ b/glhr.cpp
@@ -57,7 +57,7 @@ EX }
 EX void glError(const char* GLcall, const char* file, const int line) {
   GLenum errCode = glGetError();
   if(errCode!=GL_NO_ERROR) {
-    println(hlog, format("OPENGL ERROR #%i: in file %s on line %i :: %s",errCode,file, line, GLcall));
+    println(hlog, hr::format("OPENGL ERROR #%i: in file %s on line %i :: %s",errCode,file, line, GLcall));
     }
   }
 
@@ -75,7 +75,7 @@ struct glwrap {
 void glwrap::act(const char *when) {
   GLenum errCode = glGetError();
   if(errCode!=GL_NO_ERROR) {
-    println(hlog, format("GL error %i %s: %s:%i", errCode, when, msg, line));
+    println(hlog, hr::format("GL error %i %s: %s:%i", errCode, when, msg, line));
     }
   }
 
@@ -332,7 +332,7 @@ EX int compileShader(int type, const string& s) {
     int lineno = 1;
     string cline = "";
     for(char c: s+"\n") {
-      if(c == '\n') println(hlog, format("%4d : ", lineno), cline), lineno++, cline = "";
+      if(c == '\n') println(hlog, hr::format("%4d : ", lineno), cline), lineno++, cline = "";
       else cline += c;
       }
     println(hlog, "===");

--- a/goldberg.cpp
+++ b/goldberg.cpp
@@ -234,7 +234,7 @@ EX namespace gp {
     auto& wc = get_mapping(at);
     auto wcw = get_localwalk(wc, dir);
     auto& wc1 = get_mapping(at + eudir(dir));
-    DEBB0(DF_GP, (format("  md:%02d s:%d", wc.mindir, wc.cw.spin)); )
+    DEBB0(DF_GP, (hr::format("  md:%02d s:%d", wc.mindir, wc.cw.spin)); )
     DEBB0(DF_GP, ("  connection ", at, "/", dir, " ", wc.cw+dir, "=", wcw, " ~ ", at+eudir(dir), "/", dir1, " "); )
     if(!wc1.cw.at) {
       wc1.start = wc.start;

--- a/help.cpp
+++ b/help.cpp
@@ -586,8 +586,7 @@ EX string generateHelpForWall(eWall w) {
 void buteol(string& s, int current, int req) {
   int siz = isize(s);
   if(s[siz-1] == '\n') s.resize(siz-1);
-  char buf[100]; sprintf(buf, " (%d/%d)", current, req);
-  s += buf; s += "\n";
+  s += hr::format(" (%d/%d)\n", current, req);
   }
 
 EX string generateHelpForMonster(eMonster m) {
@@ -930,7 +929,7 @@ EX void describeMouseover() {
       }
 
     if(buggyGeneration) {
-      char buf[80]; sprintf(buf, " %p H=%d M=%d", hr::voidp(c), c->landparam, c->mpdist); out += buf;
+      out += hr::format(" %p H=%d M=%d", hr::voidp(c), c->landparam, c->mpdist);
       }
     
     if(randomPatternsMode)

--- a/history.cpp
+++ b/history.cpp
@@ -470,7 +470,7 @@ EX namespace history {
       auto save_band_segment = [&] {
         string fname = name_format;
         replace_str(fname, "$DATE", timebuf);
-        replace_str(fname, "$ID", format("%03d", segid++));
+        replace_str(fname, "$ID", hr::format("%03d", segid++));
         IMAGESAVE(band, fname.c_str());
 
         if(dospiral) 

--- a/history.cpp
+++ b/history.cpp
@@ -498,10 +498,7 @@ EX namespace history {
           
           pushScreen(progress_screen);
   
-          char buf[128];
-          sprintf(buf, "#%03d", segid);
-  
-          progress(s0 + buf + " ("+its(j+bonus)+"/"+its(siz+bonus+bonus-1)+")"); */
+          progress(s0 + hr::format("#%03d (%d/%d)", segid, j+bonus, siz+bonus+bonus-1)); */
   
           // calcparam(); current_display->radius = bandhalf;
           phase = j; movetophase();

--- a/hprint.cpp
+++ b/hprint.cpp
@@ -33,9 +33,9 @@ EX int debugflags = DF_INIT | DF_ERROR | DF_WARN | DF_MSG | DF_TIME | DF_LOG;
 
 EX string s0;
 
-EX string its(int i) { char buf[64]; sprintf(buf, "%d", i); return buf; }
+EX string its(int i) { return hr::format("%d", i); }
 
-EX string itsh8(int i) {static char buf[16]; sprintf(buf, "%08X", i); return buf; }
+EX string itsh8(int i) { return hr::format("%08X", i); }
 
 EX string fts(ld x, int prec IS(6)) {
   std::stringstream ss;
@@ -399,9 +399,9 @@ EX string llts(long long i) {
     if(i < 10) return its((int) i);
     return llts(i/10) + its(i%10);
 }
-EX string itsh(unsigned int i) {static char buf[16]; sprintf(buf, "%03X", i); return buf; }
-EX string itsh(int i) {static char buf[16]; sprintf(buf, "%03X", i); return buf; }
-EX string itsh2(int i) {static char buf[16]; sprintf(buf, "%02X", i); return buf; }
+EX string itsh(unsigned int i) { return hr::format("%03X", i); }
+EX string itsh(int i) { return hr::format("%03X", i); }
+EX string itsh2(int i) { return hr::format("%02X", i); }
 
 EX string itsh(unsigned long long i) {
   int i0 = int(i);
@@ -483,9 +483,7 @@ template<class T> T deserialize(const string& s) {
 EX string as_hexstring(string o) {
   string res;
   for(char x: o) {
-    char buf[4];
-    sprintf(buf, "%02X", (unsigned char)(x));
-    res += buf;
+    res += hr::format("%02X", (unsigned char)(x));
     }
   return res;
   }

--- a/hprint.cpp
+++ b/hprint.cpp
@@ -507,8 +507,8 @@ EX string from_hexstring(string o) {
 EX string as_cstring(string o) {
   string s = "string(\"";
   for(char c: o)
-    s += format("\\x%02x", (unsigned char) c);
-  s += format("\", %d)", isize(o));
+    s += hr::format("\\x%02x", (unsigned char) c);
+  s += hr::format("\", %d)", isize(o));
   return s;
   }
 
@@ -520,7 +520,7 @@ EX string as_nice_cstring(string o) {
     else if(c == 10)
       s += "\\n";
     else
-      s += format("\\x%02x", (unsigned char) c);
+      s += hr::format("\\x%02x", (unsigned char) c);
   s += "\"";
   return s;
   }

--- a/hyperroid/app/src/main/java/com/roguetemple/hyperroid/HyperRogue.java
+++ b/hyperroid/app/src/main/java/com/roguetemple/hyperroid/HyperRogue.java
@@ -456,7 +456,7 @@ public class HyperRogue extends Activity implements SensorEventListener {
                  @Override
                  public boolean onError(MediaPlayer mp, int what, int extra)
                  {
-                     /* Toast.makeText(getApplicationContext(), String.format("Error(%s%s)", what, extra),
+                     /* Toast.makeText(getApplicationContext(), String.hr::format("Error(%s%s)", what, extra),
                              Toast.LENGTH_SHORT).show(); */
                      return true;
                  }

--- a/intra.cpp
+++ b/intra.cpp
@@ -1162,7 +1162,7 @@ EX void add_options() {
     cell *c = centerover->move(point_direction);
     if(c && c->wall == waWaxWall) {
       color_t col = c->landparam;
-      dialog::addBoolItem("we are facing floor (color " + format("%06X", col) + ")", colors_of_floors.count(col), 'n');
+      dialog::addBoolItem("we are facing floor (color " + hr::format("%06X", col) + ")", colors_of_floors.count(col), 'n');
       dialog::add_action([col] {
         if(colors_of_floors.count(col)) colors_of_floors.erase(col);
         else colors_of_floors.insert(col);

--- a/language.cpp
+++ b/language.cpp
@@ -10,10 +10,10 @@
 #include "hyper.h"
 namespace hr {
 
-EX const string dnameof(eMonster m) { return m >= 0 && m < motypes ? minf[m].name : format("[MONSTER %d]", m); }
-EX const string dnameof(eLand l) { return l >= 0 && l < landtypes ? linf[l].name : format("[LAND %d]", l); }
-EX const string dnameof(eWall w) { return w >= 0 && w < walltypes ? winf[w].name : format("[WALL %d]", w); }
-EX const string dnameof(eItem i) { return i >= 0 && i < ittypes ? iinf[i].name : format("[ITEM %d]", i); }
+EX const string dnameof(eMonster m) { return m >= 0 && m < motypes ? minf[m].name : hr::format("[MONSTER %d]", m); }
+EX const string dnameof(eLand l) { return l >= 0 && l < landtypes ? linf[l].name : hr::format("[LAND %d]", l); }
+EX const string dnameof(eWall w) { return w >= 0 && w < walltypes ? winf[w].name : hr::format("[WALL %d]", w); }
+EX const string dnameof(eItem i) { return i >= 0 && i < ittypes ? iinf[i].name : hr::format("[ITEM %d]", i); }
 
 #if HDR
 #define NUMLAN 8

--- a/mobile.cpp
+++ b/mobile.cpp
@@ -26,15 +26,13 @@ string buildScoreDescription() {
 
   for(int i=0; i<ittypes; i++) if(items[i]) {
     string t = XLATN(iinf[i].name);
-    sprintf(buf2, " %s (%d)", t.c_str(), items[i]);
-    s += buf2;
+    s += hr::format(" %s (%d)", t.c_str(), items[i]);
     }
   s += "\n";
   s += XLAT("Kills: ") + its(tkills());
   for(int i=1; i<motypes; i++) if(kills[i]) {
     string t = XLATN(minf[i].name);
-    sprintf(buf2, " %s (%d)", t.c_str(), kills[i]);
-    s += buf2;
+    s += hr::format(" %s (%d)", t.c_str(), kills[i]);
     }
   s += "\n";
 

--- a/netgen.cpp
+++ b/netgen.cpp
@@ -439,9 +439,7 @@ EX namespace netgen {
     for(int ix=0; ix<PX; ix++) {
       for(int y=0; y<qy; y++) for(int x=0; x<qx; x++)
         qpixel(quarter,x,y) = qpixel(net, x+qx*ix, y+qy*iy);
-      char buf[64];
-      sprintf(buf, "papermodel-page%d%d" IMAGEEXT, iy, ix);
-      IMAGESAVE(quarter, buf);
+      IMAGESAVE(quarter, hr::format("papermodel-page%d%d" IMAGEEXT, iy, ix).c_str());
       }
     
     SDL_FreeSurface(net);

--- a/quit.cpp
+++ b/quit.cpp
@@ -27,9 +27,7 @@ EX int getgametime() {
   }
 
 EX string getgametime_s(int timespent IS(getgametime())) {
-  char buf[20];
-  sprintf(buf, "%d:%02d", timespent/60, timespent % 60);
-  return buf;
+  return hr::format("%d:%02d", timespent/60, timespent % 60);
   }
 
 EX bool display_yasc_codes;

--- a/reg3.cpp
+++ b/reg3.cpp
@@ -1589,7 +1589,7 @@ EX namespace reg3 {
       ld err;
       
       for(auto& p2: altmap[alt]) if((err = intval(tC0(p2.second), hT)) < 1e-3) {
-        if(err > worst_error1) println(hlog, format("worst_error1 = %lg", double(worst_error1 = err)));
+        if(err > worst_error1) println(hlog, hr::format("worst_error1 = %lg", double(worst_error1 = err)));
         // println(hlog, "YES found in ", isize(altmap[alt]));
         if(DEB) println(hlog, "-> found ", p2.first);
         int fb = 0;
@@ -1604,7 +1604,7 @@ EX namespace reg3 {
         for(int d2=0; d2<S7; d2++) {
           hyperpoint back = p2.second * tC0(cgi.adjmoves[d2]);
           if((err = intval(back, old)) < 1e-3) {
-            if(err > worst_error2) println(hlog, format("worst_error2 = %lg", double(worst_error2 = err)));
+            if(err > worst_error2) println(hlog, hr::format("worst_error2 = %lg", double(worst_error2 = err)));
             if(p2.first->move(d2)) println(hlog, "error: repeated edge");
             p2.first->c.connect(d2, parent, d, false);
             fix_distances(p2.first, parent);
@@ -2416,7 +2416,7 @@ EX namespace reg3 {
           println(f, "face ", t, " ", id++, " ", isize(fa));
           for(auto& h: fa) {
             auto h1 = kleinize(h);
-            println(f, format("%.20f %.20f %.20f", h1[0], h1[1], h1[2]));
+            println(f, hr::format("%.20f %.20f %.20f", h1[0], h1[1], h1[2]));
             }
           }
         println(f);
@@ -2431,7 +2431,7 @@ EX namespace reg3 {
           transmatrix T = quotient_map->adj(c, i);
           for(int i=0; i<4; i++) {
             for(int j=0; j<4; j++) {
-              print(f, format("%.20f", T[i][j]), j == 3 ? "\n" : " ");
+              print(f, hr::format("%.20f", T[i][j]), j == 3 ? "\n" : " ");
               }
             }
           println(f);

--- a/rogueviz/ads/display.cpp
+++ b/rogueviz/ads/display.cpp
@@ -105,7 +105,7 @@ void draw_game_cell(const cell_to_draw& cd) {
     }
 
   if(view_proper_times) {
-    string str = format(tformat, cd.center.shift / ads_time_unit);
+    string str = hr::format(tformat, cd.center.shift / ads_time_unit);
     queuestr(shiftless(rgpushxto0(cd.center.h)), .1, str, 0xFF4040, 8);
     }
 
@@ -167,7 +167,7 @@ void draw_game_cell(const cell_to_draw& cd) {
       }
 
     if(view_proper_times && rock.type != oParticle) {
-      string str = format(tformat, rock.pt_main.shift / ads_time_unit);
+      string str = hr::format(tformat, rock.pt_main.shift / ads_time_unit);
       queuestr(shiftless(rgpushxto0(rock.pt_main.h)), .1, str, 0xFFFFFF, 8);
       }
     }
@@ -213,7 +213,7 @@ void draw_game_cell(const cell_to_draw& cd) {
     queuecurve(shiftless(Id), 0xFF, shipcolor, PPR::MONSTER_FOOT);
 
     if(view_proper_times) {
-      string str = format(tformat, (cr.shift + rock.start) / ads_time_unit);
+      string str = hr::format(tformat, (cr.shift + rock.start) / ads_time_unit);
       queuestr(shiftless(rgpushxto0(cr.h)), .1, str, 0xC0C0C0, 8);
       }
     }
@@ -350,13 +350,13 @@ void view_ads_game() {
       poly_outline = 0xFF;
 
       if(view_proper_times) {
-        string str = format(tformat, ship_pt / ads_time_unit);
+        string str = hr::format(tformat, ship_pt / ads_time_unit);
         queuestr(shiftless(Id), .1, str, 0xFFFFFF, 8);
         }
       }
     
     if(paused && view_proper_times) {
-      string str = format(tformat, view_pt / ads_time_unit);
+      string str = hr::format(tformat, view_pt / ads_time_unit);
       queuestr(shiftless(Id), .1, str, 0xFFFF00, 8);
       }
     }

--- a/rogueviz/ads/ds-game.cpp
+++ b/rogueviz/ads/ds-game.cpp
@@ -29,7 +29,7 @@ struct rock_generator {
     };
 
   void report(string s) {
-    println(hlog, lalign(10, format(tformat, cshift/ds_time_unit)), ": ", s);
+    println(hlog, lalign(10, hr::format(tformat, cshift/ds_time_unit)), ": ", s);
     };
 
   ld rand_range(ld a, ld b) { return lerp(a, b, randd()); };
@@ -585,7 +585,7 @@ void view_ds_game() {
       if(view_proper_times && rock.type != oParticle) {
         ld t = rock.pt_main.shift;
         if(rock.type == oMainRock) t += current.shift;
-        string str = format(tformat, t / ds_time_unit);
+        string str = hr::format(tformat, t / ds_time_unit);
         queuestr(shiftless(sphereflip * rgpushxto0(rock.pt_main.h)), .1, str, 0xFFFF00, 8);
         }
       
@@ -638,7 +638,7 @@ void view_ds_game() {
         }
 
       if(view_proper_times) {
-        string str = format(tformat, (cr.shift + ss.start) / ds_time_unit);
+        string str = hr::format(tformat, (cr.shift + ss.start) / ds_time_unit);
         queuestr(shiftless(sphereflip * rgpushxto0(cr.h)), .1, str, 0xC0C0C0, 8);
         }
       }
@@ -664,13 +664,13 @@ void view_ds_game() {
       poly_outline = 0xFF;
 
       if(view_proper_times) {
-        string str = format(tformat, ship_pt / ds_time_unit);
+        string str = hr::format(tformat, ship_pt / ds_time_unit);
         queuestr(shiftless(sphereflip), .1, str, 0xFFFFFF, 8);
         }
       }
     
     if(paused && view_proper_times) {
-      string str = format(tformat, view_pt / ds_time_unit);
+      string str = hr::format(tformat, view_pt / ds_time_unit);
       queuestr(shiftless(sphereflip), .1, str, 0xFFFF00, 8);
       }
 

--- a/rogueviz/ads/resources.cpp
+++ b/rogueviz/ads/resources.cpp
@@ -94,7 +94,7 @@ void display(int id, int y, ld val, ld maxv, ld tank, ld unit) {
   
   if(maxv == 0) {
     string s;
-    if(main_rock) s = format(tformat, current.shift);
+    if(main_rock) s = hr::format(tformat, current.shift);
     else s = its(val + .5);
 
     queuestr(sta, ctr, 0, 20, s, col >> 8, 1, 0);

--- a/rogueviz/banachtarski.cpp
+++ b/rogueviz/banachtarski.cpp
@@ -499,7 +499,7 @@ void bantar_record() {
     vid.xres = vid.yres = TSIZE;
     banachtarski::bantar_frame();
     
-    IMAGESAVE(rbuf.render(), ("bantar/" + format("%05d", fr) + IMAGEEXT).c_str());
+    IMAGESAVE(rbuf.render(), ("bantar/" + hr::format("%05d", fr) + IMAGEEXT).c_str());
     printf("GL %5d/%5d\n", i, 10000);
     fr++;
     }

--- a/rogueviz/bringris.cpp
+++ b/rogueviz/bringris.cpp
@@ -1755,7 +1755,7 @@ void run() {
       perfect_linewidth = 0;
       shot::shot_aa = 2;
       vid.linewidth *= 2;
-      shot::take(format("bringris-%04d.png", id++), [] { draw_screen(vid.xres, false); });
+      shot::take(hr::format("bringris-%04d.png", id++), [] { draw_screen(vid.xres, false); });
       vid.linewidth /= 2;
       }
     #endif

--- a/rogueviz/collatz.cpp
+++ b/rogueviz/collatz.cpp
@@ -274,7 +274,7 @@ struct storydata { int s; int e; const char *text; } story[] = {
 #undef T
 #endif
 
-string its05(int i) { char buf[64]; sprintf(buf, "%05d", i); return buf; }
+string its05(int i) { return hr::format("%05d", i); }
 
 int dimid(char x) {
   if(x >= 'a' && x < 'a' + GDIM) return x - 'a';

--- a/rogueviz/cvl.cpp
+++ b/rogueviz/cvl.cpp
@@ -97,7 +97,7 @@ int readArgs() {
       for(auto& loc: p.second.locs) {
         dynamicval<transmatrix> dv(View, loc.lView);
         dynamicval<cell*> dc(centerover, loc.lco);
-        shot::take(format(s.c_str(), p.first, i++));
+        shot::take(hr::format(s.c_str(), p.first, i++));
         }
       }
     }

--- a/rogueviz/dhrg/betweenness.cpp
+++ b/rogueviz/dhrg/betweenness.cpp
@@ -32,7 +32,7 @@ int tallybox_total(qtybox& box) {
   }
 
 string segdesc(segment *s) {
-  return format("(%s-%s: len=%d, qty=%d/%d)", get_path(s->left).c_str(), get_path(s->right).c_str(), segmentlen(s), get0(s->qty), tallybox_total(s->qty));
+  return hr::format("(%s-%s: len=%d, qty=%d/%d)", get_path(s->left).c_str(), get_path(s->right).c_str(), segmentlen(s), get0(s->qty), tallybox_total(s->qty));
   }
 
 
@@ -342,7 +342,7 @@ void compute_betweenness(bool verify) {
     auto b = betweenness3(c1);
     // add_to_set(c1, 1, 0);
     auto b4 = betweenness4(c1);
-    print(hlog, format("B;%10Ld;%10Ld;%20.10Lf;%3d;%-40s", b.first, b.second, b4, vertices[i]->lev, rogueviz::vdata[i].name.c_str()));
+    print(hlog, hr::format("B;%10Ld;%10Ld;%20.10Lf;%3d;%-40s", b.first, b.second, b4, vertices[i]->lev, rogueviz::vdata[i].name.c_str()));
     if(verify) {
       /*
       betweenness_type a = b.first;
@@ -364,7 +364,7 @@ void compute_betweenness(bool verify) {
     else printf("\n");
     pb++;
     }
-  if(verify) println(hlog, format("errorcount = %d/%d\n", errorcount, errorcount2));
+  if(verify) println(hlog, hr::format("errorcount = %d/%d\n", errorcount, errorcount2));
   }
 
 void build(mycell *c, int lev, string s) {

--- a/rogueviz/dhrg/dhrg.cpp
+++ b/rogueviz/dhrg/dhrg.cpp
@@ -45,7 +45,7 @@ void memoryInfo() {
   }
 
 void debugtally() {
-  print(hlog, "T"); for(int i=0; i<MAXDIST; i++) if(tally[i]) print(hlog, format(" %4d/%4lld", edgetally[i], tally[i]));
+  print(hlog, "T"); for(int i=0; i<MAXDIST; i++) if(tally[i]) print(hlog, hr::format(" %4d/%4lld", edgetally[i], tally[i]));
   println(hlog, " .. %", loglikopt()); 
   }
 

--- a/rogueviz/dhrg/embedder.cpp
+++ b/rogueviz/dhrg/embedder.cpp
@@ -142,7 +142,7 @@ int move_restart() {
   print(hlog, " stats:");
   for(int a=0; a<2; a++) for(int b=0; b<128; b++) {
     int d = distances_map[a][b];
-    if(d) print(hlog, format(" %d/%d:%d", a,b, d));
+    if(d) print(hlog, hr::format(" %d/%d:%d", a,b, d));
     }
   println(hlog, "\n");
   return lastmoves = moves;
@@ -157,7 +157,7 @@ void verifycs() {
     edgecs += edgetally[u] * u*u,
     totalcs += tally[u] * u*u;
   
-  print(hlog, "edgecs=", format("%lld", edgecs), " totalcs=", format("%lld", totalcs));
+  print(hlog, "edgecs=", hr::format("%lld", edgecs), " totalcs=", hr::format("%lld", totalcs));
   }
 
 void preparegraph() {

--- a/rogueviz/dhrg/gridmapping.cpp
+++ b/rogueviz/dhrg/gridmapping.cpp
@@ -61,15 +61,15 @@ void do_analyze_grid(int maxv) {
     ld wE2 = wstats[d][2];
     ld wVr = wE2 - wE * wE;
 
-    print(hlog, format("d=%2d: q = %8d E = %12.8" PLDF " dif = %12.8" PLDF " Vr = %12.8" PLDF " Vr/(d-1)=%12.8" PLDF,
+    print(hlog, hr::format("d=%2d: q = %8d E = %12.8" PLDF " dif = %12.8" PLDF " Vr = %12.8" PLDF " Vr/(d-1)=%12.8" PLDF,
       d, q, E, dif, Vr, Vd));
 
-    if(0) print(hlog, format(" | <%" PLDF "> ex = %12.8" PLDF " d.ex = %12.8" PLDF " Vr = %12.8" PLDF, wstats[d][0], wE, wE - lwE, wVr));
+    if(0) print(hlog, hr::format(" | <%" PLDF "> ex = %12.8" PLDF " d.ex = %12.8" PLDF " Vr = %12.8" PLDF, wstats[d][0], wE, wE - lwE, wVr));
     
     ld Sigma = sqrt(Vr);
     sort(distances[d].begin(), distances[d].end());
     if(Sigma) for(int u=1; u<8; u++)
-      print(hlog, format(" %8.5" PLDF, (distances[d][u * isize(distances[d]) / 8] - E) / Sigma));
+      print(hlog, hr::format(" %8.5" PLDF, (distances[d][u * isize(distances[d]) / 8] - E) / Sigma));
     
     println(hlog);
     lwE = wE;

--- a/rogueviz/dhrg/loglik.cpp
+++ b/rogueviz/dhrg/loglik.cpp
@@ -78,7 +78,7 @@ ld bestll2(ld a, ld ab) { return bestll(a, ab-a); }
 template<class T> void fix_logistic_parameters(logistic& l, const T& f, const char *name, ld eps) {
   indenter_finish im("fix_logistic_parameters");
   ld cur = f(l);
-  println(hlog, format("%s = %20.10" PLDF " (R=%10.5" PLDF " T=%" PLDF ")", name, cur, l.R, l.T));
+  println(hlog, hr::format("%s = %20.10" PLDF " (R=%10.5" PLDF " T=%" PLDF ")", name, cur, l.R, l.T));
 
   for(ld step=1; step>eps; step /= 2) {
     
@@ -94,7 +94,7 @@ template<class T> void fix_logistic_parameters(logistic& l, const T& f, const ch
     while(true) { l.T -= step; ld t = f(l); if(t <= cur) break; cur = t; }
     l.T += step;
 
-    println(hlog, format("%s = %20.10" PLDF " (R=%10.5" PLDF " T=%10.5" PLDF ")", name, cur, l.R, l.T));
+    println(hlog, hr::format("%s = %20.10" PLDF " (R=%10.5" PLDF " T=%10.5" PLDF ")", name, cur, l.R, l.T));
     fflush(stdout);
     }
   }
@@ -269,7 +269,7 @@ void writestats() {
   ld placement_loglik = loglik_placement();
   
   for(int u=0; u<MAXDIST; u++) if(tally[u]) {
-    println(hlog, format("* %4d: %8d / %12Ld = %lf %.10" PLDF " %.10" PLDF, 
+    println(hlog, hr::format("* %4d: %8d / %12Ld = %lf %.10" PLDF " %.10" PLDF, 
       u, edgetally[u], tally[u], double(edgetally[u]) / tally[u], 
       saved_logistic.yes(u), current_logistic.yes(u)));
     }
@@ -393,7 +393,7 @@ void fast_loglik_cont(logistic& l, const logisticfun& f, const char *name, ld st
   if(name) println(hlog, "fix_logistic_parameters");
   indenter_finish im(name);
   ld cur = f(l);
-  if(name) println(hlog, format("%s = %20.10" PLDF " (R=%10.5" PLDF " T=%" PLDF ")", name, cur, l.R, l.T));
+  if(name) println(hlog, hr::format("%s = %20.10" PLDF " (R=%10.5" PLDF " T=%" PLDF ")", name, cur, l.R, l.T));
 
   map<pair<double, double>, double> memo;
   auto ff = [&] () {
@@ -424,7 +424,7 @@ void fast_loglik_cont(logistic& l, const logisticfun& f, const char *name, ld st
     
     if(changed) goto loop;
 
-    if(name) println(hlog, format("%s = %20.10" PLDF " (R=%10.5" PLDF " T=%10.5" PLDF ")", name, cur, l.R, l.T));
+    if(name) println(hlog, hr::format("%s = %20.10" PLDF " (R=%10.5" PLDF " T=%10.5" PLDF ")", name, cur, l.R, l.T));
     fflush(stdout);
     }
   }

--- a/rogueviz/dhrg/visualize.cpp
+++ b/rogueviz/dhrg/visualize.cpp
@@ -29,13 +29,12 @@ void show_likelihood() {
     for(int i=0; i<MAXDIST; i++) bonus_tally[i] = 0;
 
   for(int u=0; u<MAXDIST; u++) if(tally[u] || bonus_tally[u]) {
-    char buf[20];
-    sprintf(buf, "%.6lf", lc_type == 'R' ? current_logistic.yes(u) : double(edgetally[u] * 1. / tally[u]));    
+    string value = hr::format("%.6lf", lc_type == 'R' ? current_logistic.yes(u) : double(edgetally[u] * 1. / tally[u]));
     string s = its(u);
     if(isize(s) == 1) s = "0" + s;
     s += ": " + its(edgetally[u]) + " / " + its(tally[u]);
     if(bonus_tally[u]) s += " [" + its(bonus_edgetally[u]) + "/" + its(bonus_tally[u]) + "]";
-    dialog::addSelItem(s, buf, 0);
+    dialog::addSelItem(s, value, 0);
     }
   
   char letters[3] = {'O', 'R', 'M'};

--- a/rogueviz/dynamic-wfc.cpp
+++ b/rogueviz/dynamic-wfc.cpp
@@ -397,7 +397,7 @@ void wfc() {
   
   if(isize(freq)) println(hlog, "last freq = ", freq[0].prob);
   println(hlog, "freq size = ", isize(freq));
-  println(hlog, "tfreq = ", format("%lld", tfreq));
+  println(hlog, "tfreq = ", hr::format("%lld", tfreq));
   println(hlog, "trans size = ", isize(trans));
   println(hlog, "next code = ", nextcode);
   clearMessages();

--- a/rogueviz/janko.cpp
+++ b/rogueviz/janko.cpp
@@ -100,7 +100,7 @@ void experiment() {
     println(hlog, "found: ", tie(ia, ib));
 
     for(auto& row: jms[ia]) {
-      for(auto& i: row) print(hlog, format("%2d, ", i));
+      for(auto& i: row) print(hlog, hr::format("%2d, ", i));
       println(hlog);
       }
     }

--- a/rogueviz/magiccube.cpp
+++ b/rogueviz/magiccube.cpp
@@ -31,7 +31,7 @@ void build(crystal::coord co, int at) {
     if(WDIM == 3) c->wall = waWaxWall;
     }
 
-  println(hlog, co, " twos = ", twos, " index = ", index, " set = ", format("%06X", c->landparam));
+  println(hlog, co, " twos = ", twos, " index = ", index, " set = ", hr::format("%06X", c->landparam));
   
   }
 

--- a/rogueviz/newconf.cpp
+++ b/rogueviz/newconf.cpp
@@ -921,7 +921,7 @@ void ncee() {
     displayButton(vid.xres - 8, 8 + vid.fsize, XLAT("(v) menu"), 'v', 16);
 
   if(algo_ticks)
-    displaystr(8, 8 + vid.fsize, 0, vid.fsize * 2, format("%d.%03d", algo_ticks/1000, algo_ticks%1000), 0xFFFFFF, 0);
+    displaystr(8, 8 + vid.fsize, 0, vid.fsize * 2, hr::format("%d.%03d", algo_ticks/1000, algo_ticks%1000), 0xFFFFFF, 0);
   
   keyhandler = [=] (int sym, int uni) {
     // dialog::handleNavigation(sym, uni);
@@ -977,7 +977,7 @@ void ncee() {
         fmap = genellipse(D, i * degree / slow);
         println(hlog, "i = ", i);
         for(int a=0; a<10; a++) iterate();
-        if(i >= 0) shot::take(format(rfname.c_str(), i), draw_ncee);
+        if(i >= 0) shot::take(hr::format(rfname.c_str(), i), draw_ncee);
         }
       }
     };

--- a/rogueviz/nilrider/level.cpp
+++ b/rogueviz/nilrider/level.cpp
@@ -388,7 +388,7 @@ void level::init() {
   start.timer = 0;
   current = start;
   println(hlog, "start.where = ", start.where);
-  println(hlog, "current.where = ", current.where, " : ", format("%p", &current));
+  println(hlog, "current.where = ", current.where, " : ", hr::format("%p", &current));
   
   int qgoals = isize(goals);
   records[0].resize(qgoals, 0);

--- a/rogueviz/nilrider/save.cpp
+++ b/rogueviz/nilrider/save.cpp
@@ -22,7 +22,7 @@ void save() {
         if(l->records[i][g]) {
           println(f, "*RECORD");
           println(f, l->name);
-          println(f, format("%d %d %f", i, g, l->records[i][g]));
+          println(f, hr::format("%d %d %f", i, g, l->records[i][g]));
           }
       }
     }
@@ -40,7 +40,7 @@ void save() {
       println(f, l->name);
       println(f, p.name);
       println(f, isize(p.plan));
-      for(auto t: p.plan) println(f, format("%.6f %.6f %.6f %.6f", t.at[0], t.at[1], t.vel[0], t.vel[1]));
+      for(auto t: p.plan) println(f, hr::format("%.6f %.6f %.6f %.6f", t.at[0], t.at[1], t.vel[0], t.vel[1]));
       println(f);
       }
     }

--- a/rogueviz/nilrider/timestamp.cpp
+++ b/rogueviz/nilrider/timestamp.cpp
@@ -217,7 +217,7 @@ void timestamp::centerview(level *lev) {
   }
 
 string format_timer(ld t) {
-  return format("%d:%02d.%02d", int(t / 60), int(t) % 60, int(frac(t) * 100));
+  return hr::format("%d:%02d.%02d", int(t / 60), int(t) % 60, int(frac(t) * 100));
   }
 
 void timestamp::draw_instruments(level* l) {
@@ -373,7 +373,7 @@ void timestamp::draw_instruments(level* l) {
 
   string s;
   if(loaded_or_planned) s = "R";
-  else if(reversals) s = format("+%d", reversals);
+  else if(reversals) s = hr::format("+%d", reversals);
   else return;
   displaystr(vid.xres - vid.fsize, vid.fsize*4, 0, vid.fsize, s, 0, 16);
   }

--- a/rogueviz/presentation.cpp
+++ b/rogueviz/presentation.cpp
@@ -196,7 +196,7 @@ string latex_packages =
 string latex_cachename(string s, flagtype flags) {
   unsigned hash = 0;
   for(char c: latex_packages + s) hash = (hash << 3) ^ hash ^ c ^ flags;
-  return format("latex-cache/%08X.png", hash);
+  return hr::format("latex-cache/%08X.png", hash);
   }
 
 /* note: you pdftopng from the xpdf package for this to work! */
@@ -330,7 +330,7 @@ void show_animation(presmode mode, string s, int sx, int sy, int frames, int fps
     /* actually load */
     array<int, 2> tab;
     if(pipe(&tab[0])) {
-      addMessage(format("Error: %s", strerror(errno)));
+      addMessage(hr::format("Error: %s", strerror(errno)));
       return;
       }
 

--- a/rogueviz/sag.cpp
+++ b/rogueviz/sag.cpp
@@ -431,7 +431,7 @@ namespace sag {
       
       if(t2 - tl > 980) {
         tl = t2;
-        println(hlog, format("it %12Ld temp %6.4f [1/e at %13.6f] cost = %f ",
+        println(hlog, hr::format("it %12Ld temp %6.4f [1/e at %13.6f] cost = %f ",
           numiter, double(sag::temperature), (double) exp(sag::temperature),
           double(sag::cost)));
         }
@@ -458,7 +458,7 @@ namespace sag {
         auto t2 = SDL_GetTicks();
         if(t2 - t1 > 1000) {
           t1 = t2;
-          println(hlog, format("it %12Ld temp %6.4f [1/e at %13.6f] cost = %f ",
+          println(hlog, hr::format("it %12Ld temp %6.4f [1/e at %13.6f] cost = %f ",
             numiter, double(sag::temperature), (double) exp(sag::temperature),
             double(sag::cost)));
           }
@@ -491,7 +491,7 @@ namespace sag {
     if(t < (sag_ittime+1) / 2) ipturn *= 2;
     else if(t > sag_ittime * 2) ipturn /= 2;
     else ipturn = ipturn * sag_ittime / t;
-    print(hlog, format("it %12Ld temp %6.4f [2:%8.6f,10:%8.6f,50:%8.6f] cost = %f\n",
+    print(hlog, hr::format("it %12Ld temp %6.4f [2:%8.6f,10:%8.6f,50:%8.6f] cost = %f\n",
       numiter, double(sag::temperature), 
       (double) exp(-2 * exp(-sag::temperature)),
       (double) exp(-10 * exp(-sag::temperature)),
@@ -701,7 +701,7 @@ namespace sag {
 
     dhrg::fast_loglik_cont(lgemb, lc, nullptr, 1, 1e-5);
     
-    println(hlog, "loglik = ", format("%.6f", lc(lgemb)), " R = ", lgemb.R, " T = ", lgemb.T, " iterations = ", embiter);
+    println(hlog, "loglik = ", hr::format("%.6f", lc(lgemb)), " R = ", lgemb.R, " T = ", lgemb.T, " iterations = ", embiter);
     }
 
   void reassign_embedding() {
@@ -769,7 +769,7 @@ namespace sag {
     for(int i=0; i<isize(sagid); i++) {
       println(f, vdata[i].name);
       for(int d=0; d<MDIM; d++)
-        println(f, format("%.20f", placement[i][d]));
+        println(f, hr::format("%.20f", placement[i][d]));
       }
     }
 
@@ -1153,8 +1153,8 @@ void geo_stats() {
     out("geometry", S3 >= OINF ? "tree" : hyperbolic ? "hyperbolic" : sphere ? "sphere" : euclid ? "euclid" : nil ? "nil" : sol ? "solv" : mproduct ? "product" : "other");
     out("closed", max_sag_dist == isize(sagcells) ? 0 : closed_manifold ? 1 : 0);
     out("angular", angular);
-    for(int p: {1, 10, 50}) { out(format("sagdist%02d", p), sorted_sagdist[(p * sorted_sagdist.size()) / 100]); }
-    for(int p: {1, 2, 3, 4}) { out(format("d%d", p), d[p]); }
+    for(int p: {1, 10, 50}) { out(hr::format("sagdist%02d", p), sorted_sagdist[(p * sorted_sagdist.size()) / 100]); }
+    for(int p: {1, 2, 3, 4}) { out(hr::format("d%d", p), d[p]); }
     println(hlog);
     #undef out
     }
@@ -1173,7 +1173,7 @@ void output_stats() {
   dhrg::prepare_pairs(DN, [] (int i) { return edges_yes[i]; });
   dhrg::greedy_routing(routing_result, [] (int i, int j) { return sagdist[sagid[i]][sagid[j]]; });
   print(hlog, "CSV;", logid++, ";", isize(sagnode), ";", DN, ";", isize(sagedges), ";", lgsag.R, ";", lgsag.T, ";", cost, ";", mAP, ";", routing_result.suc / routing_result.tot, ";", routing_result.routedist / routing_result.bestdist);
-  if(report_tempi) print(hlog, ";", hightemp,";",lowtemp,";",format("%lld", numiter));
+  if(report_tempi) print(hlog, ";", hightemp,";",lowtemp,";",hr::format("%lld", numiter));
   println(hlog);
   }
 

--- a/screenshot.cpp
+++ b/screenshot.cpp
@@ -1448,7 +1448,7 @@ EX bool record_video(string fname IS(videofile), bool_reaction_t rec IS(record_a
   
   array<int, 2> tab;
   if(pipe(&tab[0])) {
-    addMessage(format("Error: %s", strerror(errno)));
+    addMessage(hr::format("Error: %s", strerror(errno)));
     return false;
     }
   println(hlog, "tab = ", tab);

--- a/screenshot.cpp
+++ b/screenshot.cpp
@@ -53,13 +53,13 @@ EX always_false in;
     static int id;
     id++; id %= 10;
     if(divby == 1) {
-      sprintf(buf[id], "%d", val); return buf[id];
+      snprintf(buf[id], 20, "%d", val); return buf[id];
       }
     else if(divby <= 10) {
-      sprintf(buf[id], "%.1f", val*1./divby); return buf[id];
+      snprintf(buf[id], 20, "%.1f", val*1./divby); return buf[id];
       }
     else {
-      sprintf(buf[id], "%.2f", val*1./divby); return buf[id];
+      snprintf(buf[id], 20, "%.2f", val*1./divby); return buf[id];
       }
     }
   
@@ -78,7 +78,7 @@ EX always_false in;
       else fill = 0xFFFFFFFF;
       }
     
-    sprintf(buf, "style=\"stroke:#%06x;stroke-opacity:%.3" PLDF ";stroke-width:%" PLDF "px;fill:#%06x;fill-opacity:%.3" PLDF "\"",
+    snprintf(buf, 600, "style=\"stroke:#%06x;stroke-opacity:%.3" PLDF ";stroke-width:%" PLDF "px;fill:#%06x;fill-opacity:%.3" PLDF "\"",
       (stroke>>8) & 0xFFFFFF, cta(stroke),
       width/divby,
       (fill>>8) & 0xFFFFFF, cta(fill)

--- a/usershapes.cpp
+++ b/usershapes.cpp
@@ -102,7 +102,7 @@ void geometry_information::prepare_usershapes() {
       if(sh->flags & POLY_VCONVEX) vcon++;
       if(sh->flags & POLY_CCONVEX) ccon++;
       }
-    println(hlog, format("inverse = %d isside = %d vcon = %d ccon = %d", inve, issi, vcon, ccon));
+    println(hlog, hr::format("inverse = %d isside = %d vcon = %d ccon = %d", inve, issi, vcon, ccon));
     }
   
   initPolyForGL();


### PR DESCRIPTION
Apple Xcode now gives `-Wdeprecated-declarations` on any attempt to use `sprintf`. Which is silly, but also easy to fix.
C++20 adds `std::format`, which will ambiguate unqualified calls to `hr::format`. Add the qualification everywhere.
No intended functional change (although the calls to `hr::format` _do_ perform more memory allocations than the old raw `s[n]printf` calls did).