### PR TITLE
Consistently apply `override` (and not `virtual`) to overriding virtuals

### DIFF
--- a/cell.cpp
+++ b/cell.cpp
@@ -99,11 +99,11 @@ struct hrmap_standard : hrmap {
   ld spin_angle(cell *c, int d) override;
   double spacedist(cell *c, int i) override;
   void find_cell_connection(cell *c, int d) override;
-  virtual int shvid(cell *c) override;
-  virtual hyperpoint get_corner(cell *c, int cid, ld cf) override;
-  virtual transmatrix master_relative(cell *c, bool get_inverse) override;
-  virtual bool link_alt(heptagon *h, heptagon *alt, hstate firststate, int dir) override;
-  virtual void on_dim_change() override;
+  int shvid(cell *c) override;
+  hyperpoint get_corner(cell *c, int cid, ld cf) override;
+  transmatrix master_relative(cell *c, bool get_inverse) override;
+  bool link_alt(heptagon *h, heptagon *alt, hstate firststate, int dir) override;
+  void on_dim_change() override;
   };
 
 void clearfrom(heptagon*);

--- a/config.cpp
+++ b/config.cpp
@@ -133,7 +133,7 @@ template<class T> struct enum_setting : list_setting {
       }
     *value = (T) parseint(s);
     }
-  virtual void check_change() override {
+  void check_change() override {
     if(*value != last_value) {
       last_value = *value;
       add_to_changed(this);
@@ -173,15 +173,15 @@ template<class T> struct val_setting : public setting {
   T *value, last_value, anim_value, dft;
 
   bool affects(void *v) override { return v == value; }
-  virtual void check_change() override {
+  void check_change() override {
     if(*value != last_value) {
       last_value = *value;
       add_to_changed(this);
       }
     }
 
-  virtual bool anim_unchanged() override { return *value == anim_value; }
-  virtual void anim_restore() override { *value = anim_value; if(reaction) reaction(); }
+  bool anim_unchanged() override { return *value == anim_value; }
+  void anim_restore() override { *value = anim_value; if(reaction) reaction(); }
 
   virtual void load_from_raw(const string& s) { throw hr_exception("load_from_raw not defined"); }
 
@@ -221,7 +221,7 @@ struct float_setting : public val_setting<ld> {
   supersaver *make_saver() override;
   void show_edit_option(int key) override;
   void load_from_raw(const string& s) override { *value = parseld(s); }
-  virtual cld get_cld() override { return *value; }
+  cld get_cld() override { return *value; }
   void set_cld_raw(cld x) override { *value = real(x); }
   };
 
@@ -249,12 +249,12 @@ struct int_setting : public val_setting<int> {
     return this;
     }
 
-  virtual cld get_cld() override { return *value; }
+  cld get_cld() override { return *value; }
 
   void load_from_raw(const string& s) override { *value = parseint(s); }
   void set_cld_raw(cld x) override { *value = (int)(real(x) + .5); }
 
-  virtual void check_change() override {
+  void check_change() override {
     if(*value != last_value) {
       last_value = *value;
       add_to_changed(this);
@@ -313,7 +313,7 @@ struct bool_setting : public val_setting<bool> {
 
   void load_from_raw(const string& s) override { *value = parseint(s); }
 
-  virtual cld get_cld() override { return *value; }
+  cld get_cld() override { return *value; }
   };
 
 struct custom_setting : public setting {
@@ -322,9 +322,9 @@ struct custom_setting : public setting {
   function<cld()> custom_value;
   function<bool(void*)> custom_affect;
   void show_edit_option(int key) override { custom_viewer(key); }
-  supersaver *make_saver() { throw hr_exception("make_saver for custom_setting"); }
+  supersaver *make_saver() override { throw hr_exception("make_saver for custom_setting"); }
   bool affects(void *v) override { return custom_affect(v); }
-  virtual void check_change() override {
+  void check_change() override {
     if(custom_value() != last_value) {
       last_value = custom_value();
       add_to_changed(this);
@@ -410,40 +410,40 @@ template<> struct saver<int> : dsaver<int> {
   explicit saver(int& val) : dsaver<int>(val) { }
   string save() override { return its(val); }
   void load(const string& s) override { val = atoi(s.c_str()); }
-  virtual void clone(struct local_parameter_set& lps, void *value) override { addsaver(*(int*) value, lps.label + name); }
-  virtual void swap_with(supersaver *s) override { swap(val, ((saver<int>*)s)->val); }
+  void clone(struct local_parameter_set& lps, void *value) override { addsaver(*(int*) value, lps.label + name); }
+  void swap_with(supersaver *s) override { swap(val, ((saver<int>*)s)->val); }
   };
 
 template<> struct saver<char> : dsaver<char> {
   explicit saver(char& val) : dsaver<char>(val) { }
   string save() override { return its(val); }
   void load(const string& s) override { val = atoi(s.c_str()); }
-  virtual void clone(struct local_parameter_set& lps, void *value) override { addsaver(*(char*) value, lps.label + name); }
-  virtual void swap_with(supersaver *s) override { swap(val, ((saver<char>*)s)->val); }
+  void clone(struct local_parameter_set& lps, void *value) override { addsaver(*(char*) value, lps.label + name); }
+  void swap_with(supersaver *s) override { swap(val, ((saver<char>*)s)->val); }
   };
 
 template<> struct saver<bool> : dsaver<bool> {
   explicit saver(bool& val) : dsaver<bool>(val) { }
   string save() override { return val ? "yes" : "no"; }
   void load(const string& s) override { val = isize(s) && s[0] == 'y'; }
-  virtual void clone(struct local_parameter_set& lps, void *value) override { addsaver(*(bool*) value, lps.label + name); }
-  virtual void swap_with(supersaver *s) override { swap(val, ((saver<bool>*)s)->val); }
+  void clone(struct local_parameter_set& lps, void *value) override { addsaver(*(bool*) value, lps.label + name); }
+  void swap_with(supersaver *s) override { swap(val, ((saver<bool>*)s)->val); }
   };
 
 template<> struct saver<unsigned> : dsaver<unsigned> {
   explicit saver(unsigned& val) : dsaver<unsigned>(val) { }
   string save() override { return itsh(val); }
   void load(const string& s) override { val = (unsigned) strtoll(s.c_str(), NULL, 16); }
-  virtual void clone(struct local_parameter_set& lps, void *value) override { addsaver(*(unsigned*) value, lps.label + name); }
-  virtual void swap_with(supersaver *s) override { swap(val, ((saver<unsigned>*)s)->val); }
+  void clone(struct local_parameter_set& lps, void *value) override { addsaver(*(unsigned*) value, lps.label + name); }
+  void swap_with(supersaver *s) override { swap(val, ((saver<unsigned>*)s)->val); }
   };
 
 template<> struct saver<string> : dsaver<string> {
   explicit saver(string& val) : dsaver<string>(val) { }
   string save() override { return val; }
   void load(const string& s) override { val = s; }
-  virtual void clone(struct local_parameter_set& lps, void *value) override { addsaver(*(string*) value, lps.label + name); }
-  virtual void swap_with(supersaver *s) override { swap(val, ((saver<string>*)s)->val); }
+  void clone(struct local_parameter_set& lps, void *value) override { addsaver(*(string*) value, lps.label + name); }
+  void swap_with(supersaver *s) override { swap(val, ((saver<string>*)s)->val); }
   };
 
 template<> struct saver<matrix_eq> : supersaver {
@@ -468,8 +468,8 @@ template<> struct saver<matrix_eq> : supersaver {
     ss.s = s;
     for(int a=0; a<4; a++) for(int b=0; b<4; b++) scan(ss, val[a][b]);
     }
-  virtual void clone(struct local_parameter_set& lps, void *value) override { addsaver(*(matrix_eq*) value, lps.label + name); }
-  virtual void swap_with(supersaver *s) override { swap(val, ((saver<matrix_eq>*)s)->val); }
+  void clone(struct local_parameter_set& lps, void *value) override { addsaver(*(matrix_eq*) value, lps.label + name); }
+  void swap_with(supersaver *s) override { swap(val, ((saver<matrix_eq>*)s)->val); }
   };
 
 template<> struct saver<ld> : dsaver<ld> {
@@ -479,8 +479,8 @@ template<> struct saver<ld> : dsaver<ld> {
     if(s == "0.0000000000e+000") ; // ignore!
     else val = atof(s.c_str()); 
     }
-  virtual void clone(struct local_parameter_set& lps, void *value) override { addsaver(*(ld*) value, lps.label + name); }
-  virtual void swap_with(supersaver *s) { swap(val, ((saver<ld>*)s)->val); }
+  void clone(struct local_parameter_set& lps, void *value) override { addsaver(*(ld*) value, lps.label + name); }
+  void swap_with(supersaver *s) override { swap(val, ((saver<ld>*)s)->val); }
   };
 #endif
 #endif

--- a/dialogs.cpp
+++ b/dialogs.cpp
@@ -1811,7 +1811,7 @@ EX namespace dialog {
     int editpos = 0;
     string *edited_string;
     string view_edited_string();
-    void draw();
+    void draw() override;
     void start_editing(string& s);
     bool handle_edit_string(int sym, int uni, function<string(int, int)> checker = editchecker);
     };

--- a/embeddings.cpp
+++ b/embeddings.cpp
@@ -520,7 +520,7 @@ struct emb_actual : embedding_method {
 /** embed in the 3D variant of the same geometry */
 
 struct emb_same_in_same : emb_actual {
-  virtual bool is_same_in_same() override { return true; }
+  bool is_same_in_same() override { return true; }
   transmatrix intermediate_to_actual_translation(hyperpoint i) override { return rgpushxto0(logical_to_actual(i)); }
   hyperpoint actual_to_intermediate(hyperpoint a) override { return actual_to_logical(a); }
   hyperpoint orthogonal_move(const hyperpoint& h, ld z) override {
@@ -601,7 +601,7 @@ struct emb_same_in_same : emb_actual {
 /** embed in the product geometry */
 
 struct emb_product_embedding : emb_actual {
-  virtual bool is_product_embedding() override { return true; }
+  bool is_product_embedding() override { return true; }
   transmatrix intermediate_to_actual_translation(hyperpoint i) override { return rgpushxto0(logical_to_actual(i)); }
   hyperpoint actual_to_intermediate(hyperpoint a) override { return actual_to_logical(a); }
   hyperpoint flatten(hyperpoint h) override { h /= exp(zlevel(h)); return h; }
@@ -913,7 +913,7 @@ struct emb_euc_cylinder_sl2 : emb_euc_cylinder_twisted {
 struct emb_euc_in_sph : emb_euclid_noniso {
   bool is_euc_in_sph() override { return true; }
   ld center_z() override { return 1; }
-  // virtual ld height_limit(ld sign) override { return sign < 0 ? 0 : 90._deg; }
+  // ld height_limit(ld sign) override { return sign < 0 ? 0 : 90._deg; }
   hyperpoint actual_to_intermediate(hyperpoint a) override { 
     ld tx = hypot(a[0], a[2]);
     ld ty = hypot(a[1], a[3]);

--- a/hprint.cpp
+++ b/hprint.cpp
@@ -150,7 +150,7 @@ struct fhstream : hstream {
   void write_chars(const char* c, size_t i) override { if(fwrite(c, i, 1, f) != 1) throw hstream_exception(); }
   void read_chars(char* c, size_t i) override { if(fread(c, i, 1, f) != 1) throw hstream_exception(); }
   char read_char() override { char c; read_chars(&c, 1); return c; }
-  virtual void flush() override { fflush(f); }
+  void flush() override { fflush(f); }
   };
 
 struct shstream : hstream { 

--- a/hyper_function.h
+++ b/hyper_function.h
@@ -29,7 +29,7 @@ struct function_state : function_state_base<R, Args...> {
     function_state_base<R, Args...> *clone() const override {
         return new function_state(*this);
     }
-    virtual funbase* as_funbase() override {
+    funbase* as_funbase() override {
       if(std::is_base_of<funbase, T>::value) return (funbase*) (&t_);
       return nullptr;
       }

--- a/nonisotropic.cpp
+++ b/nonisotropic.cpp
@@ -1391,8 +1391,8 @@ EX namespace hybrid {
       return PIU( currentmap->full_shvid(c1) );
       }
 
-    virtual transmatrix spin_to(cell *c, int d, ld bonus) override { if(d >= c->type-2) return Id; c = get_where(c).first; return fix4_f( in_underlying([&] { return currentmap->spin_to(c, d, bonus); }) ); }
-    virtual transmatrix spin_from(cell *c, int d, ld bonus) override { if(d >= c->type-2) return Id; c = get_where(c).first; return fix4_f( in_underlying([&] { return currentmap->spin_from(c, d, bonus); }) ); }
+    transmatrix spin_to(cell *c, int d, ld bonus) override { if(d >= c->type-2) return Id; c = get_where(c).first; return fix4_f( in_underlying([&] { return currentmap->spin_to(c, d, bonus); }) ); }
+    transmatrix spin_from(cell *c, int d, ld bonus) override { if(d >= c->type-2) return Id; c = get_where(c).first; return fix4_f( in_underlying([&] { return currentmap->spin_from(c, d, bonus); }) ); }
 
     subcellshape& get_cellshape(cell *c) override {      
       int id = full_shvid(c);
@@ -1705,7 +1705,7 @@ EX namespace product {
         }
       }
 
-    virtual transmatrix ray_iadj(cell *c, int i) override {
+    transmatrix ray_iadj(cell *c, int i) override {
       if(i == c->type-2) return (cpush(2, +cgi.plevel));
       if(i == c->type-1) return (cpush(2, -cgi.plevel));
       transmatrix T;

--- a/reg3.cpp
+++ b/reg3.cpp
@@ -2199,7 +2199,7 @@ EX namespace reg3 {
       return relative_matrix_recursive(h2, h1);
       }
     
-    virtual bool link_alt(heptagon *h, heptagon *alt, hstate firststate, int dir) override {
+    bool link_alt(heptagon *h, heptagon *alt, hstate firststate, int dir) override {
       return ruleset_link_alt(h, alt, firststate, dir);
       }
     };

--- a/rulegen.cpp
+++ b/rulegen.cpp
@@ -2370,7 +2370,7 @@ struct hrmap_rulegen : hrmap {
   
   bool strict_tree_rules() override { return true; }
 
-  virtual bool link_alt(heptagon *h, heptagon *alt, hstate firststate, int dir) override {
+  bool link_alt(heptagon *h, heptagon *alt, hstate firststate, int dir) override {
     auto& hts = treestates[h->fieldval];
     int psid = hts.sid;
     


### PR DESCRIPTION
Three functions were missing `override`, triggering `-Wsuggest-override` on Clang.
Many functions had redundant `virtual ... override`.