### PR TITLE
Fix -Wunused-but-set-variable warnings from Clang

### DIFF
--- a/3d-models.cpp
+++ b/3d-models.cpp
@@ -548,8 +548,6 @@ void geometry_information::make_revolution_cut(hpcshape &sh, int each, ld push, 
   
   auto gbody = body;
   
-  int it = 0;
-  
   vector<int> nextid(n);
   vector<int> lastid(n);
   vector<bool> stillin(n, true);
@@ -558,7 +556,6 @@ void geometry_information::make_revolution_cut(hpcshape &sh, int each, ld push, 
   nextid[n-1] = n-1; lastid[0] = 0;
 
   while(true) {
-    it++;
     int cand = -1;
     ld cv = 0;
     for(int i=1; i<n-1; i++) if(stillin[i]) {
@@ -787,7 +784,7 @@ void geometry_information::adjust_eye(hpcshape& eye, hpcshape head, ld shift_eye
   hyperpoint pscenter = psmin(center);
   
   ld pos = 0;
-  int qty = 0, qtyall = 0;
+  int qty = 0;
   
   vector<hyperpoint> pss;
   
@@ -801,7 +798,6 @@ void geometry_information::adjust_eye(hpcshape& eye, hpcshape head, ld shift_eye
   for(int i=0; i<isize(pss); i+=3) if(pss[i][2] < zmid || (WDIM == 3 && !gproduct)) {
     ld d = sqhypot_d(2, pss[i]-pscenter) + sqhypot_d(2, pss[i+1]-pscenter) + sqhypot_d(2, pss[i+2]-pscenter);
     if(d < mindist) mindist = d, pos = min(min(pss[i][2], pss[i+1][2]), pss[i+2][2]), qty++;
-    qtyall++;
     }
   
   if(&eye == &shSkullEyes) cgi.eyelevel_human = pos = zc(eyepos) - 0.06 * SH * 0.05;

--- a/barriers.cpp
+++ b/barriers.cpp
@@ -976,9 +976,6 @@ EX bool valid_dir(const vector<char>& ad, int j, cell *c) {
   auto ad1 = currentmap->get_cellshape(c).dirdist[j];
   int a = 0;
   for(auto& dd: ad1) if(dd == 1) a++;
-
-  int a0 = 0;
-  for(auto& dd: ad) if(dd == 1) a0++;
   return a < 6;
   }
 

--- a/earcut.hpp
+++ b/earcut.hpp
@@ -280,11 +280,8 @@ void Earcut<N>::earcutLinked(Node* ear, int pass) {
     Node* prev;
     Node* next;
 
-    int iterations = 0;
-
     // iterate through ears, slicing them one by one
     while (ear->prev != ear->next) {
-        iterations++;
         prev = ear->prev;
         next = ear->next;
 

--- a/rulegen3.cpp
+++ b/rulegen3.cpp
@@ -1288,9 +1288,6 @@ EX void test_transducers() {
           swap(cum, result);
           ctid = t_origin[ctid].at->cmove(c)->id;
           }
-        int err = 0;
-        for(auto duc: cum) for(auto p: duc.second.t)
-          if(p.first.first == ENDED || p.first.second != p.first.first) err++;
         throw_identity_errors(cum, cyc.dirs);
         if(id_size != isize(cum)) println(hlog, "error: identity not recovered correctly");
         }


### PR DESCRIPTION
You should take a close look at each of these removals, because they _might_ indicate a typo further down — maybe the variable was intended to be used, but accidentally wasn't. For example, `return a < 6;` is very suspicious: should it have been `return a0 < 6;` ?