### PR TITLE
Change `static const` to `static constexpr` wherever possible

### DIFF
--- a/archimedean.cpp
+++ b/archimedean.cpp
@@ -96,11 +96,11 @@ struct archimedean_tiling {
 #endif
 
 #if HDR
-static const int sfPH = 1;
-static const int sfLINE = 2;
-static const int sfCHESS = 4;
-static const int sfTHREE = 8;
-static const int sfSEMILINE = 16;
+static constexpr int sfPH = 1;
+static constexpr int sfLINE = 2;
+static constexpr int sfCHESS = 4;
+static constexpr int sfTHREE = 8;
+static constexpr int sfSEMILINE = 16;
 #endif
 
 #if CAP_ARCM

--- a/cell.cpp
+++ b/cell.cpp
@@ -772,9 +772,9 @@ EX int celldist(cell *c) {
   }
 
 #if HDR
-static const int ALTDIST_BOUNDARY = 99999;
-static const int ALTDIST_UNKNOWN = 99998;
-static const int ALTDIST_ERROR = 90000;
+static constexpr int ALTDIST_BOUNDARY = 99999;
+static constexpr int ALTDIST_UNKNOWN = 99998;
+static constexpr int ALTDIST_ERROR = 90000;
 #endif
 
 EX int celldistAlt(cell *c) {
@@ -863,12 +863,12 @@ EX int updir_alt(heptagon *h) {
 
 
 #if HDR
-static const int RPV_MODULO = 5;
-static const int RPV_RAND = 0;
-static const int RPV_ZEBRA = 1;
-static const int RPV_EMERALD = 2;
-static const int RPV_PALACE = 3;
-static const int RPV_CYCLE = 4;
+static constexpr int RPV_MODULO = 5;
+static constexpr int RPV_RAND = 0;
+static constexpr int RPV_ZEBRA = 1;
+static constexpr int RPV_EMERALD = 2;
+static constexpr int RPV_PALACE = 3;
+static constexpr int RPV_CYCLE = 4;
 #endif
 
 // x mod 5 = pattern type

--- a/celldrawer.cpp
+++ b/celldrawer.cpp
@@ -77,8 +77,8 @@ inline void drawcell(cell *c, const shiftmatrix& V) {
   }
 #endif
 
-static const int trapcol[4] = {0x904040, 0xA02020, 0xD00000, 0x303030};
-static const int terracol[8] = {0xD000, 0xE25050, 0xD0D0D0, 0x606060, 0x303030, 0x181818, 0x0080, 0x8080};
+static constexpr int trapcol[4] = {0x904040, 0xA02020, 0xD00000, 0x303030};
+static constexpr int terracol[8] = {0xD000, 0xE25050, 0xD0D0D0, 0x606060, 0x303030, 0x181818, 0x0080, 0x8080};
 
 void celldrawer::addaura() {
   hr::addaura(tC0(V), darkened(aura_color), fd);

--- a/checkmove.cpp
+++ b/checkmove.cpp
@@ -36,11 +36,11 @@ EX vector<bool> legalmoves;
 EX vector<int> move_issues;
 
 #if HDR
-static const int miVALID = 10000;
-static const int miENTITY = 11000;
-static const int miRESTRICTED = 10100;
-static const int miTHREAT = 10010;
-static const int miWALL = 10001;
+static constexpr int miVALID = 10000;
+static constexpr int miENTITY = 11000;
+static constexpr int miRESTRICTED = 10100;
+static constexpr int miTHREAT = 10010;
+static constexpr int miWALL = 10001;
 #endif
 
 EX int checked_move_issue;

--- a/classes.cpp
+++ b/classes.cpp
@@ -426,59 +426,59 @@ enum eSlimegroup { sgNone, sgCave, sgWater, sgFloorA, sgFloorB, sgVine, sgTree }
 
 #if HDR
 // we use CF not MF to avoid confusion with MF_ movement flags
-static const flagtype CF_NOGHOST = Flag(0);
-static const flagtype CF_RAIDER = Flag(1);
-static const flagtype CF_PRINCESS = Flag(2);
-static const flagtype CF_MIMIC = Flag(3);
-static const flagtype CF_GOK = Flag(4);
-static const flagtype CF_NONLIVING = Flag(5);
-static const flagtype CF_METAL = Flag(6);
-static const flagtype CF_STUNNABLE = Flag(7);
-static const flagtype CF_HP = Flag(8);
-static const flagtype CF_MOUNTABLE = Flag(9);
-static const flagtype CF_FRIENDLY = Flag(10);
-static const flagtype CF_PLAYER = Flag(11);
-static const flagtype CF_BUG = Flag(12);
-static const flagtype CF_IVY = Flag(13);
-static const flagtype CF_PART = Flag(14);
-static const flagtype CF_MUTANTIVY = Flag(15);
-static const flagtype CF_ANYIVY = Flag(16);
-static const flagtype CF_BULLET = Flag(17);
-static const flagtype CF_DEMON = Flag(18);
-static const flagtype CF_WORM = Flag(19);
-static const flagtype CF_WITCH = Flag(20);
-static const flagtype CF_BIRD = Flag(21);
-static const flagtype CF_SLOWMOVER = Flag(22);
-static const flagtype CF_MAGNETIC = Flag(23);
-static const flagtype CF_SWITCH = Flag(24);
-static const flagtype CF_GHOST = Flag(25);
-static const flagtype CF_SHARK = Flag(26);
-static const flagtype CF_SLIME = Flag(27);
-static const flagtype CF_DRAGON = Flag(28);
-static const flagtype CF_KRAKEN = Flag(29);
-static const flagtype CF_NOBLOW = Flag(30);
-static const flagtype CF_MULTITILE = Flag(31);
-static const flagtype CF_LEADER = Flag(32);
-static const flagtype CF_FLYING = Flag(33);
-static const flagtype CF_ATTACK_THRU_VINE = Flag(34);
-static const flagtype CF_ATTACK_NONADJACENT = Flag(35);
-static const flagtype CF_NOHIGHLIGHT = Flag(36);
-static const flagtype CF_INACTIVE = Flag(37);
-static const flagtype CF_UNARMED = Flag(38);
-static const flagtype CF_IGNORE_PLATE = Flag(39);
-static const flagtype CF_BULL = Flag(40);
-static const flagtype CF_TROLL = Flag(41);
-static const flagtype CF_IGNORE_SMELL = Flag(42);
-static const flagtype CF_RATLING = Flag(43);
-static const flagtype CF_POWER = Flag(44);
-static const flagtype CF_GHOSTMOVER = Flag(45);
-static const flagtype CF_TECHNICAL = Flag(46);
-static const flagtype CF_MOVED = Flag(47);
-static const flagtype CF_FACING = Flag(48);
-static const flagtype CF_FACE_UP = Flag(49);
-static const flagtype CF_FACE_SIDE = Flag(50);
-static const flagtype CF_HIGH_THREAT = Flag(51);
-static const flagtype CF_SPAM = Flag(52);
+static constexpr flagtype CF_NOGHOST = Flag(0);
+static constexpr flagtype CF_RAIDER = Flag(1);
+static constexpr flagtype CF_PRINCESS = Flag(2);
+static constexpr flagtype CF_MIMIC = Flag(3);
+static constexpr flagtype CF_GOK = Flag(4);
+static constexpr flagtype CF_NONLIVING = Flag(5);
+static constexpr flagtype CF_METAL = Flag(6);
+static constexpr flagtype CF_STUNNABLE = Flag(7);
+static constexpr flagtype CF_HP = Flag(8);
+static constexpr flagtype CF_MOUNTABLE = Flag(9);
+static constexpr flagtype CF_FRIENDLY = Flag(10);
+static constexpr flagtype CF_PLAYER = Flag(11);
+static constexpr flagtype CF_BUG = Flag(12);
+static constexpr flagtype CF_IVY = Flag(13);
+static constexpr flagtype CF_PART = Flag(14);
+static constexpr flagtype CF_MUTANTIVY = Flag(15);
+static constexpr flagtype CF_ANYIVY = Flag(16);
+static constexpr flagtype CF_BULLET = Flag(17);
+static constexpr flagtype CF_DEMON = Flag(18);
+static constexpr flagtype CF_WORM = Flag(19);
+static constexpr flagtype CF_WITCH = Flag(20);
+static constexpr flagtype CF_BIRD = Flag(21);
+static constexpr flagtype CF_SLOWMOVER = Flag(22);
+static constexpr flagtype CF_MAGNETIC = Flag(23);
+static constexpr flagtype CF_SWITCH = Flag(24);
+static constexpr flagtype CF_GHOST = Flag(25);
+static constexpr flagtype CF_SHARK = Flag(26);
+static constexpr flagtype CF_SLIME = Flag(27);
+static constexpr flagtype CF_DRAGON = Flag(28);
+static constexpr flagtype CF_KRAKEN = Flag(29);
+static constexpr flagtype CF_NOBLOW = Flag(30);
+static constexpr flagtype CF_MULTITILE = Flag(31);
+static constexpr flagtype CF_LEADER = Flag(32);
+static constexpr flagtype CF_FLYING = Flag(33);
+static constexpr flagtype CF_ATTACK_THRU_VINE = Flag(34);
+static constexpr flagtype CF_ATTACK_NONADJACENT = Flag(35);
+static constexpr flagtype CF_NOHIGHLIGHT = Flag(36);
+static constexpr flagtype CF_INACTIVE = Flag(37);
+static constexpr flagtype CF_UNARMED = Flag(38);
+static constexpr flagtype CF_IGNORE_PLATE = Flag(39);
+static constexpr flagtype CF_BULL = Flag(40);
+static constexpr flagtype CF_TROLL = Flag(41);
+static constexpr flagtype CF_IGNORE_SMELL = Flag(42);
+static constexpr flagtype CF_RATLING = Flag(43);
+static constexpr flagtype CF_POWER = Flag(44);
+static constexpr flagtype CF_GHOSTMOVER = Flag(45);
+static constexpr flagtype CF_TECHNICAL = Flag(46);
+static constexpr flagtype CF_MOVED = Flag(47);
+static constexpr flagtype CF_FACING = Flag(48);
+static constexpr flagtype CF_FACE_UP = Flag(49);
+static constexpr flagtype CF_FACE_SIDE = Flag(50);
+static constexpr flagtype CF_HIGH_THREAT = Flag(51);
+static constexpr flagtype CF_SPAM = Flag(52);
 
 enum eMonster {
   #define MONSTER(a,b,c,d,e,f,g,h) d,
@@ -536,16 +536,16 @@ EX genderswitch_t genderswitch[NUM_GS] = {
 #if HDR
 enum eOrbshape { osNone, osLove, osRanged, osOffensive, osFriend, osUtility, osDirectional, osWarping, osFrog, osPowerUtility, osProtective, osMovement, osTerraform };
 
-static const flagtype ZERO = 0;
+static constexpr flagtype ZERO = 0;
 
-static const flagtype IF_SHARD = Flag(0);
-static const flagtype IF_FIREPROOF = Flag(1);
-static const flagtype IF_PROTECTION = Flag(2);
-static const flagtype IF_EMPATHY = Flag(3);
-static const flagtype IF_RANGED = Flag(4);
-static const flagtype IF_SHMUPLIFE = Flag(5);
-static const flagtype IF_REVIVAL = Flag(6);
-static const flagtype IF_CURSE = Flag(7);
+static constexpr flagtype IF_SHARD = Flag(0);
+static constexpr flagtype IF_FIREPROOF = Flag(1);
+static constexpr flagtype IF_PROTECTION = Flag(2);
+static constexpr flagtype IF_EMPATHY = Flag(3);
+static constexpr flagtype IF_RANGED = Flag(4);
+static constexpr flagtype IF_SHMUPLIFE = Flag(5);
+static constexpr flagtype IF_REVIVAL = Flag(6);
+static constexpr flagtype IF_CURSE = Flag(7);
 
 // 0 = basic treasure, 1 = other item, 2 = power orb, 3 = not an item
 #define IC_TREASURE 0
@@ -578,28 +578,28 @@ EX itemtype iinf[ittypes] = {
 // --- wall types ---
 
 #if HDR
-static const flagtype WF_WATER = Flag(0);
-static const flagtype WF_BOAT = Flag(1);
-static const flagtype WF_CHASM = Flag(2);
-static const flagtype WF_NOFLIGHT = Flag(3);
-static const flagtype WF_FIRE = Flag(4);
-static const flagtype WF_THUMPER = Flag(5);
-static const flagtype WF_ACTIVABLE = Flag(6);
-static const flagtype WF_ALCHEMY = Flag(7);
-static const flagtype WF_RED = Flag(8);
-static const flagtype WF_WALL = Flag(9);
-static const flagtype WF_PUSHABLE = Flag(10);
-static const flagtype WF_CONE = Flag(11);
-static const flagtype WF_STDTREE = Flag(12);
-static const flagtype WF_GRAVE = Flag(13);
-static const flagtype WF_REPTILE = Flag(14);
-static const flagtype WF_HEATCOLOR = Flag(15);
-static const flagtype WF_HIGHWALL = Flag(16);
-static const flagtype WF_THORNY = Flag(17);
-static const flagtype WF_TIMEOUT = Flag(18);
-static const flagtype WF_CISLAND = Flag(19);
-static const flagtype WF_SULPHURIC = Flag(20);
-static const flagtype WF_HALFVINE = Flag(21);
+static constexpr flagtype WF_WATER = Flag(0);
+static constexpr flagtype WF_BOAT = Flag(1);
+static constexpr flagtype WF_CHASM = Flag(2);
+static constexpr flagtype WF_NOFLIGHT = Flag(3);
+static constexpr flagtype WF_FIRE = Flag(4);
+static constexpr flagtype WF_THUMPER = Flag(5);
+static constexpr flagtype WF_ACTIVABLE = Flag(6);
+static constexpr flagtype WF_ALCHEMY = Flag(7);
+static constexpr flagtype WF_RED = Flag(8);
+static constexpr flagtype WF_WALL = Flag(9);
+static constexpr flagtype WF_PUSHABLE = Flag(10);
+static constexpr flagtype WF_CONE = Flag(11);
+static constexpr flagtype WF_STDTREE = Flag(12);
+static constexpr flagtype WF_GRAVE = Flag(13);
+static constexpr flagtype WF_REPTILE = Flag(14);
+static constexpr flagtype WF_HEATCOLOR = Flag(15);
+static constexpr flagtype WF_HIGHWALL = Flag(16);
+static constexpr flagtype WF_THORNY = Flag(17);
+static constexpr flagtype WF_TIMEOUT = Flag(18);
+static constexpr flagtype WF_CISLAND = Flag(19);
+static constexpr flagtype WF_SULPHURIC = Flag(20);
+static constexpr flagtype WF_HALFVINE = Flag(21);
 
 struct walltype {
   char  glyph;
@@ -631,23 +631,23 @@ enum eCanvasFloor { caflNone, caflM, caflFull, caflWarp, caflStar, caflCloud, ca
   caflPalace, caflDemon, caflCave, caflDesert, caflPower, caflRose, caflTurtle, caflDragon, caflReptile,
   caflHive, caflSwitch, caflTower, caflEND };
 
-static const flagtype LF_GENERATE_ALL = Flag(0);
-static const flagtype LF_ICY = Flag(1);
-static const flagtype LF_GRAVITY = Flag(2);
-static const flagtype LF_EQUI = Flag(3);
-static const flagtype LF_WARPED = Flag(4);
-static const flagtype LF_CYCLIC = Flag(5);
-static const flagtype LF_TECHNICAL = Flag(6);
-static const flagtype LF_MIRROR = Flag(7);
-static const flagtype LF_SEA = Flag(8);
-static const flagtype LF_COASTAL = Flag(9);
-static const flagtype LF_PURESEA = Flag(10);
-static const flagtype LF_ELEMENTAL = Flag(11);
-static const flagtype LF_HAUNTED = Flag(12);
-static const flagtype LF_TROLL = Flag(13);
-static const flagtype LF_INMIRROR = Flag(14);
-static const flagtype LF_INMIRRORORWALL = Flag(15);
-static const flagtype LF_ELECTRIC = Flag(17);
+static constexpr flagtype LF_GENERATE_ALL = Flag(0);
+static constexpr flagtype LF_ICY = Flag(1);
+static constexpr flagtype LF_GRAVITY = Flag(2);
+static constexpr flagtype LF_EQUI = Flag(3);
+static constexpr flagtype LF_WARPED = Flag(4);
+static constexpr flagtype LF_CYCLIC = Flag(5);
+static constexpr flagtype LF_TECHNICAL = Flag(6);
+static constexpr flagtype LF_MIRROR = Flag(7);
+static constexpr flagtype LF_SEA = Flag(8);
+static constexpr flagtype LF_COASTAL = Flag(9);
+static constexpr flagtype LF_PURESEA = Flag(10);
+static constexpr flagtype LF_ELEMENTAL = Flag(11);
+static constexpr flagtype LF_HAUNTED = Flag(12);
+static constexpr flagtype LF_TROLL = Flag(13);
+static constexpr flagtype LF_INMIRROR = Flag(14);
+static constexpr flagtype LF_INMIRRORORWALL = Flag(15);
+static constexpr flagtype LF_ELECTRIC = Flag(17);
 
 struct landtype {
   color_t color;
@@ -788,76 +788,76 @@ struct geometryinfo {
   eVariation default_variation;
   };
 
-static const flagtype qCLOSED         = 1;
-static const flagtype qANYQ            = 2;
-static const flagtype qNONORIENTABLE   = 4;
-static const flagtype qSMALL           = 8;
+static constexpr flagtype qCLOSED         = 1;
+static constexpr flagtype qANYQ            = 2;
+static constexpr flagtype qNONORIENTABLE   = 4;
+static constexpr flagtype qSMALL           = 8;
 
-static const flagtype qFIELD           = 16;
-static const flagtype qDOCKS           = 32;
-static const flagtype qZEBRA           = 64;
+static constexpr flagtype qFIELD           = 16;
+static constexpr flagtype qDOCKS           = 32;
+static constexpr flagtype qZEBRA           = 64;
 
-static const flagtype qELLIPTIC        = 128;
+static constexpr flagtype qELLIPTIC        = 128;
 
-static const flagtype qBINARY          = 256;
-static const flagtype qKITE            = 512;
+static constexpr flagtype qBINARY          = 256;
+static constexpr flagtype qKITE            = 512;
 
-static const flagtype qREGULAR         = 1024; /* not set! */
-static const flagtype qARCHI           = 2048;
-static const flagtype qHYBRID          = 4096;
-static const flagtype qCRYSTAL         = 8192;
-static const flagtype qSOL             = 16384;
-static const flagtype qEXPERIMENTAL    = 32768;
-static const flagtype qNIH             = 65536;
+static constexpr flagtype qREGULAR         = 1024; /* not set! */
+static constexpr flagtype qARCHI           = 2048;
+static constexpr flagtype qHYBRID          = 4096;
+static constexpr flagtype qCRYSTAL         = 8192;
+static constexpr flagtype qSOL             = 16384;
+static constexpr flagtype qEXPERIMENTAL    = 32768;
+static constexpr flagtype qNIH             = 65536;
 
-static const flagtype qIDEAL           = 131072;
-static const flagtype qHUGE_BOUNDED    = 262144;
-static const flagtype qOPTQ            = Flag(19);
-static const flagtype qSINGLE          = Flag(20);
+static constexpr flagtype qIDEAL           = 131072;
+static constexpr flagtype qHUGE_BOUNDED    = 262144;
+static constexpr flagtype qOPTQ            = Flag(19);
+static constexpr flagtype qSINGLE          = Flag(20);
 
-static const flagtype qDEPRECATED      = Flag(21);
-static const flagtype qINFMIXED        = Flag(22);
+static constexpr flagtype qDEPRECATED      = Flag(21);
+static constexpr flagtype qINFMIXED        = Flag(22);
 
-static const flagtype qRAYONLY         = Flag(23);
-static const flagtype qAFFINE          = Flag(24);
+static constexpr flagtype qRAYONLY         = Flag(23);
+static constexpr flagtype qAFFINE          = Flag(24);
 
-static const flagtype qULTRA           = Flag(25);
+static constexpr flagtype qULTRA           = Flag(25);
 
-static const flagtype qPORTALSPACE     = Flag(26);
+static constexpr flagtype qPORTALSPACE     = Flag(26);
 
-static const flagtype qSTRETCHABLE     = Flag(27);
+static constexpr flagtype qSTRETCHABLE     = Flag(27);
 
-static const flagtype qCAT             = Flag(28);
+static constexpr flagtype qCAT             = Flag(28);
 
-static const flagtype qAPERIODIC       = Flag(29);
-static const flagtype qHAT             = Flag(30);
+static constexpr flagtype qAPERIODIC       = Flag(29);
+static constexpr flagtype qHAT             = Flag(30);
 
-static const flagtype qFRACTAL         = Flag(31);
+static constexpr flagtype qFRACTAL         = Flag(31);
 
 // note: dnext assumes that x&7 equals 7
-static const int SEE_ALL = 50;
+static constexpr int SEE_ALL = 50;
 // note: check_football_colorability in arbitrile.cpp assumes OINF is divisible by 3
-static const int OINF = 123;
+static constexpr int OINF = 123;
 
 extern eGeometry geometry;
 extern eVariation variation;
 #endif
 
 #if HDR
-static const flagtype qsNONOR           = qANYQ | qSMALL | qCLOSED | qNONORIENTABLE;
-static const flagtype qsNONORE          = qsNONOR | qELLIPTIC;
-static const flagtype qsBQ              = qANYQ | qSMALL | qCLOSED;
-static const flagtype qsSMALL           = qANYQ | qSMALL | qCLOSED;
-static const flagtype qsSMALLN          = qANYQ | qSMALL | qCLOSED | qNONORIENTABLE;
-static const flagtype qsZEBRA           = qANYQ | qSMALL | qCLOSED | qZEBRA;
-static const flagtype qsFIELD           = qANYQ | qFIELD | qCLOSED;
-static const flagtype qsDOCKS           = qANYQ | qSMALL | qCLOSED | qDOCKS;
-static const flagtype qsSMALLB          = qSMALL | qCLOSED;
-static const flagtype qsSMALLBF         = qsSMALLB | qsFIELD | qANYQ;
-static const flagtype qsSMALLBE         = qsSMALLB | qELLIPTIC | qANYQ;
-static const flagtype qsBP              = qBINARY | qKITE;
+static constexpr flagtype qsNONOR           = qANYQ | qSMALL | qCLOSED | qNONORIENTABLE;
+static constexpr flagtype qsNONORE          = qsNONOR | qELLIPTIC;
+static constexpr flagtype qsBQ              = qANYQ | qSMALL | qCLOSED;
+static constexpr flagtype qsSMALL           = qANYQ | qSMALL | qCLOSED;
+static constexpr flagtype qsSMALLN          = qANYQ | qSMALL | qCLOSED | qNONORIENTABLE;
+static constexpr flagtype qsZEBRA           = qANYQ | qSMALL | qCLOSED | qZEBRA;
+static constexpr flagtype qsFIELD           = qANYQ | qFIELD | qCLOSED;
+static constexpr flagtype qsDOCKS           = qANYQ | qSMALL | qCLOSED | qDOCKS;
+static constexpr flagtype qsSMALLB          = qSMALL | qCLOSED;
+static constexpr flagtype qsSMALLBF         = qsSMALLB | qsFIELD | qANYQ;
+static constexpr flagtype qsSMALLBE         = qsSMALLB | qELLIPTIC | qANYQ;
+static constexpr flagtype qsBP              = qBINARY | qKITE;
 
-static const flagtype qsSINGLE          = qANYQ | qSMALL | qCLOSED | qSINGLE;
+static constexpr flagtype qsSINGLE          = qANYQ | qSMALL | qCLOSED | qSINGLE;
 #endif
 
 EX geometryinfo1 giEuclid2 = { gcEuclid,     2, 2, 3, {1,1, 0,0 } };
@@ -974,31 +974,31 @@ EX vector<geometryinfo> ginf = {
 
 #if HDR
 namespace mf {
-  static const flagtype azimuthal = 1;
-  static const flagtype cylindrical = 2; /* usually you want 'band' */
-  static const flagtype equiarea = 4;
-  static const flagtype equidistant = 8;
-  static const flagtype conformal = 16;
-  static const flagtype euc_boring = 32;
-  static const flagtype space = 64;
-  static const flagtype hyper_only = 128;
-  static const flagtype hyper_or_torus = 256;
-  static const flagtype pseudocylindrical = 512; /* includes cylindrical; usually you want 'band' or 'pseudoband' */
-  static const flagtype equivolume = 1024;
-  static const flagtype twopoint = 2048;
-  static const flagtype uses_bandshift = 4096;
-  static const flagtype broken = 8192; /* in spherical case, these are broken along the meridian 180 deg */
-  static const flagtype technical = 16384; /* don't display in the list */
-  static const flagtype product_special = (1<<15);
-  static const flagtype axial = (1<<16);
-  static const flagtype perspective = (1<<17);
-  static const flagtype orientation = (1<<18);
-  static const flagtype transition = (1<<19);
-  static const flagtype werner = (1<<20);
-  static const flagtype horocyclic = (1<<21);
+  static constexpr flagtype azimuthal = 1;
+  static constexpr flagtype cylindrical = 2; /* usually you want 'band' */
+  static constexpr flagtype equiarea = 4;
+  static constexpr flagtype equidistant = 8;
+  static constexpr flagtype conformal = 16;
+  static constexpr flagtype euc_boring = 32;
+  static constexpr flagtype space = 64;
+  static constexpr flagtype hyper_only = 128;
+  static constexpr flagtype hyper_or_torus = 256;
+  static constexpr flagtype pseudocylindrical = 512; /* includes cylindrical; usually you want 'band' or 'pseudoband' */
+  static constexpr flagtype equivolume = 1024;
+  static constexpr flagtype twopoint = 2048;
+  static constexpr flagtype uses_bandshift = 4096;
+  static constexpr flagtype broken = 8192; /* in spherical case, these are broken along the meridian 180 deg */
+  static constexpr flagtype technical = 16384; /* don't display in the list */
+  static constexpr flagtype product_special = (1<<15);
+  static constexpr flagtype axial = (1<<16);
+  static constexpr flagtype perspective = (1<<17);
+  static constexpr flagtype orientation = (1<<18);
+  static constexpr flagtype transition = (1<<19);
+  static constexpr flagtype werner = (1<<20);
+  static constexpr flagtype horocyclic = (1<<21);
   
-  static const flagtype band = (cylindrical | pseudocylindrical | uses_bandshift | orientation);
-  static const flagtype pseudoband = (pseudocylindrical | uses_bandshift | orientation);
+  static constexpr flagtype band = (cylindrical | pseudocylindrical | uses_bandshift | orientation);
+  static constexpr flagtype pseudoband = (pseudocylindrical | uses_bandshift | orientation);
   }
   
 struct modelinfo {

--- a/colors.cpp
+++ b/colors.cpp
@@ -25,7 +25,7 @@ EX unsigned char& part(color_t& col, int i) {
   }
 
 #if HDR
-static const color_t NOCOLOR = 0;
+static constexpr color_t NOCOLOR = 0;
 
 struct colortable: vector<color_t> {
   color_t& operator [] (int i) { i %= size(); if(i<0) i += size(); return ((vector<color_t>&)(*this)) [i]; }

--- a/complex.cpp
+++ b/complex.cpp
@@ -1172,10 +1172,10 @@ EX namespace whirlpool {
 EX namespace mirror {
 
   #if HDR
-  static const int SPINSINGLE = 1;
-  static const int SPINMULTI = 2;
-  static const int GO = 4;
-  static const int ATTACK = 8;
+  static constexpr int SPINSINGLE = 1;
+  static constexpr int SPINMULTI = 2;
+  static constexpr int GO = 4;
+  static constexpr int ATTACK = 8;
   #endif
   
   EX bool build(cell *c) {
@@ -1633,8 +1633,8 @@ EX namespace mirror {
     return cw;
     }
 
-  static const int CACHESIZE = 1<<12; // must be a power of 2
-  static const int CACHEMASK = CACHESIZE-1;
+  static constexpr int CACHESIZE = 1<<12; // must be a power of 2
+  static constexpr int CACHEMASK = CACHESIZE-1;
     
   pair<cell*, cellwalker> cache[CACHESIZE];
   int nextcache;
@@ -3369,7 +3369,7 @@ namespace prairie {
 
 EX namespace ca {
   EX ld prob = .2;
-  static const int MAX_NEIGHBOR = 60; /* may be larger than MAX_EDGE due to mineadj */
+  static constexpr int MAX_NEIGHBOR = 60; /* may be larger than MAX_EDGE due to mineadj */
   string carule[MAX_NEIGHBOR][2];
   
   EX eWall wlive = waFloorA;
@@ -3542,8 +3542,8 @@ int windcodes5676[] = {152,138,172,172,141,158,157,124,119,130,125,143,190,206,2
 EX namespace windmap {
 
   #if HDR
-  static const int NOWINDBELOW = 8;
-  static const int NOWINDFROM = 120;  
+  static constexpr int NOWINDBELOW = 8;
+  static constexpr int NOWINDFROM = 120;  
   #endif
 
   map<int, int> getid;

--- a/complex2.cpp
+++ b/complex2.cpp
@@ -44,7 +44,7 @@ EX namespace brownian {
     c->landparam += val;
     }
   
-  static const int FAT = (-100); // less than 0
+  static constexpr int FAT = (-100); // less than 0
 
   void recurse(cell *c, int fatten_from) {
     int dl = getDistLimit();

--- a/control.cpp
+++ b/control.cpp
@@ -34,7 +34,7 @@ EX function <bool(SDL_Event &ev)> joyhandler = [] (SDL_Event &ev) {return false;
 
 #if HDR
 // what part of the compass does 'skip turn'
-static const auto SKIPFAC = .4;
+static constexpr auto SKIPFAC = .4;
 #endif
 
 // is the player using mouse? (used for auto-cross)

--- a/crystal.cpp
+++ b/crystal.cpp
@@ -11,8 +11,8 @@ namespace hr {
 EX namespace crystal {
 
 #if HDR
-static const int MAXDIM = 7;
-static const int MAX_EDGE_CRYSTAL = 2 * MAXDIM;
+static constexpr int MAXDIM = 7;
+static constexpr int MAX_EDGE_CRYSTAL = 2 * MAXDIM;
 
 struct coord : public array<int, MAXDIM> {
   coord operator + (coord b) { for(int i=0; i<MAXDIM; i++) b[i] += self[i]; return b; }  
@@ -20,7 +20,7 @@ struct coord : public array<int, MAXDIM> {
   coord operator * (int x) { coord res; for(int i=0; i<MAXDIM; i++) res[i] = x * self[i]; return res; } 
   };
 
-static const coord c0 = {};
+static constexpr coord c0 = {};
 
 struct ldcoord : public array<ld, MAXDIM> {
   friend ldcoord operator + (ldcoord a, ldcoord b) { ldcoord r; for(int i=0; i<MAXDIM; i++) r[i] = a[i] + b[i]; return r; }
@@ -30,7 +30,7 @@ struct ldcoord : public array<ld, MAXDIM> {
   friend ld operator | (ldcoord a, ldcoord b) { ld r=0; for(int i=0; i<MAXDIM; i++) r += a[i] * b[i]; return r; }
   };
 
-static const ldcoord ldc0 = {};
+static constexpr ldcoord ldc0 = {};
 #endif
 
 #if CAP_CRYSTAL
@@ -325,7 +325,7 @@ ld sqhypot2(crystal_structure& cs, ldcoord co1, ldcoord co2) {
   return result;
   }
 
-static const int Modval = 64;
+static constexpr int Modval = 64;
 
 struct east_structure {
   map<coord, int> data;
@@ -1595,7 +1595,7 @@ EX string get_table_volume() {
         if(co[i] < mincoord) mincoord = co[i];
         if(co[i] > maxcoord) maxcoord = co[i];
         }
-      static const ld eps = 1e-4;
+      static constexpr ld eps = 1e-4;
       if(mincoord >= 0-eps && maxcoord < PERIOD-eps) {
         ld my_rad2 = rad2;
         auto cshift = (co - m->camelot_coord) / PERIOD;

--- a/dialogs.cpp
+++ b/dialogs.cpp
@@ -15,7 +15,7 @@ EX namespace dialog {
 #if HDR
   #define IFM(x) (mousing?"":x)
 
-  static const int DONT_SHOW = 16;
+  static constexpr int DONT_SHOW = 16;
 
   enum tDialogItem {diTitle, diItem, diBreak, diHelp, diInfo, diIntSlider, diSlider, diBigItem, diKeyboard, diCustom, diColorItem, diListStart, diListEnd, diMatrixItem};
 

--- a/drawing.cpp
+++ b/drawing.cpp
@@ -9,37 +9,37 @@
 namespace hr {
 
 #if HDR
-static const int POLY_DRAWLINES = 1;            // draw the lines
-static const int POLY_DRAWAREA = 2;             // draw the area
-static const int POLY_INVERSE = 4;              // draw the inverse -- useful in stereographic projection
-static const int POLY_ISSIDE = 8;               // never draw in inverse
-static const int POLY_BEHIND = 16;              // there are points behind the camera
-static const int POLY_TOOLARGE = 32;            // some coordinates are too large -- best not to draw to avoid glitches
-static const int POLY_INFRONT = 64;             // on the sphere (orthogonal projection), do not draw without any points in front
-static const int POLY_HASWALLS = 128;           // floor shapes which have their sidewalls
-static const int POLY_PLAIN = 256;              // plain floors
-static const int POLY_FULL = 512;               // full floors
-static const int POLY_HASSHADOW = 1024;         // floor shapes which have their shadows, or can use shFloorShadow
-static const int POLY_GP = 2048;                // Goldberg shapes
-static const int POLY_VCONVEX = 4096;           // Convex shape (vertex)
-static const int POLY_CCONVEX = 8192;           // Convex shape (central)
-static const int POLY_CENTERIN = 16384;         // new system of side checking 
-static const int POLY_FORCEWIDE = (1<<15);      // force wide lines
-static const int POLY_NOTINFRONT = (1<<16);     // points not in front
-static const int POLY_NIF_ERROR = (1<<17);      // points moved to the outline cross the image, disable
-static const int POLY_BADCENTERIN = (1<<18);    // new system of side checking 
-static const int POLY_PRECISE_WIDE = (1<<19);   // precise width calculation
-static const int POLY_FORCE_INVERTED = (1<<20); // force inverted
-static const int POLY_ALWAYS_IN = (1<<21);      // always draw this
-static const int POLY_TRIANGLES = (1<<22);      // made of TRIANGLES, not TRIANGLE_FAN
-static const int POLY_INTENSE = (1<<23);        // extra intense colors
-static const int POLY_DEBUG = (1<<24);          // debug this shape
-static const int POLY_PRINTABLE = (1<<25);      // these walls are printable
-static const int POLY_FAT = (1<<26);            // fatten this model in WRL export (used for Rug)
-static const int POLY_SHADE_TEXTURE = (1<<27);  // texture has 'z' coordinate for shading
-static const int POLY_ONE_LEVEL = (1<<28);      // only one level of the universal cover in SL(2,R)
-static const int POLY_APEIROGONAL = (1<<29);    // only vertices indexed up to she are drawn as the boundary
-static const int POLY_NO_FOG = (1<<30);         // disable fog for this
+static constexpr int POLY_DRAWLINES = 1;            // draw the lines
+static constexpr int POLY_DRAWAREA = 2;             // draw the area
+static constexpr int POLY_INVERSE = 4;              // draw the inverse -- useful in stereographic projection
+static constexpr int POLY_ISSIDE = 8;               // never draw in inverse
+static constexpr int POLY_BEHIND = 16;              // there are points behind the camera
+static constexpr int POLY_TOOLARGE = 32;            // some coordinates are too large -- best not to draw to avoid glitches
+static constexpr int POLY_INFRONT = 64;             // on the sphere (orthogonal projection), do not draw without any points in front
+static constexpr int POLY_HASWALLS = 128;           // floor shapes which have their sidewalls
+static constexpr int POLY_PLAIN = 256;              // plain floors
+static constexpr int POLY_FULL = 512;               // full floors
+static constexpr int POLY_HASSHADOW = 1024;         // floor shapes which have their shadows, or can use shFloorShadow
+static constexpr int POLY_GP = 2048;                // Goldberg shapes
+static constexpr int POLY_VCONVEX = 4096;           // Convex shape (vertex)
+static constexpr int POLY_CCONVEX = 8192;           // Convex shape (central)
+static constexpr int POLY_CENTERIN = 16384;         // new system of side checking 
+static constexpr int POLY_FORCEWIDE = (1<<15);      // force wide lines
+static constexpr int POLY_NOTINFRONT = (1<<16);     // points not in front
+static constexpr int POLY_NIF_ERROR = (1<<17);      // points moved to the outline cross the image, disable
+static constexpr int POLY_BADCENTERIN = (1<<18);    // new system of side checking 
+static constexpr int POLY_PRECISE_WIDE = (1<<19);   // precise width calculation
+static constexpr int POLY_FORCE_INVERTED = (1<<20); // force inverted
+static constexpr int POLY_ALWAYS_IN = (1<<21);      // always draw this
+static constexpr int POLY_TRIANGLES = (1<<22);      // made of TRIANGLES, not TRIANGLE_FAN
+static constexpr int POLY_INTENSE = (1<<23);        // extra intense colors
+static constexpr int POLY_DEBUG = (1<<24);          // debug this shape
+static constexpr int POLY_PRINTABLE = (1<<25);      // these walls are printable
+static constexpr int POLY_FAT = (1<<26);            // fatten this model in WRL export (used for Rug)
+static constexpr int POLY_SHADE_TEXTURE = (1<<27);  // texture has 'z' coordinate for shading
+static constexpr int POLY_ONE_LEVEL = (1<<28);      // only one level of the universal cover in SL(2,R)
+static constexpr int POLY_APEIROGONAL = (1<<29);    // only vertices indexed up to she are drawn as the boundary
+static constexpr int POLY_NO_FOG = (1<<30);         // disable fog for this
 
 /** \brief A graphical element that can be drawn. Objects are not drawn immediately but rather queued.
  *

--- a/euclid.cpp
+++ b/euclid.cpp
@@ -12,8 +12,8 @@ EX namespace euc {
 
   #if HDR
   struct coord : array<int, 3> {
-    coord() {}
-    coord(int x, int y, int z) { self[0] = x; self[1] = y; self[2] = z; }
+    explicit coord() = default;
+    constexpr explicit coord(int x, int y, int z) : array{x,y,z} {}
     coord& operator += (coord b) { for(int i: {0,1,2}) self[i] += b[i]; return self; }
     coord& operator -= (coord b) { for(int i: {0,1,2}) self[i] -= b[i]; return self; }
     coord operator + (coord b) const { coord a = self; return a += b; }
@@ -32,7 +32,7 @@ EX namespace euc {
   EX const coord eutester = coord(3,7,0);
   EX intmatrix euzeroall = make_array<coord>(euzero, euzero, euzero);
 
-  static const intmatrix main_axes = make_array<coord>(coord(1,0,0), coord(0,1,0), coord(0,0,1));
+  static constexpr intmatrix main_axes = make_array<coord>(coord(1,0,0), coord(0,1,0), coord(0,0,1));
   
   EX vector<coord> get_shifttable() {
     static const coord D0 = main_axes[0];

--- a/fieldpattern.cpp
+++ b/fieldpattern.cpp
@@ -77,7 +77,7 @@ EX int btspin(int id, int d) {
 
 #if HDR
 
-static const int ERR = -99;
+static constexpr int ERR = -99;
 
 struct triplet_info {
   int i, j, size;
@@ -272,7 +272,7 @@ struct fpattern {
   
   void build();
   
-  static const int MAXDIST = 120;
+  static constexpr int MAXDIST = 120;
   
   vector<char> disthep;
   vector<char> disthex;

--- a/geometry.cpp
+++ b/geometry.cpp
@@ -22,7 +22,7 @@ struct usershapelayer {
 
 extern int usershape_changes;
 
-static const int USERLAYERS = 32;
+static constexpr int USERLAYERS = 32;
 
 struct usershape { usershapelayer d[USERLAYERS]; };
 
@@ -57,15 +57,15 @@ struct hpcshape {
 #define GOLDBERG_BITS 5
 #endif
 
-static const int GOLDBERG_LIMIT = (1<<GOLDBERG_BITS);
-static const int GOLDBERG_MASK = (GOLDBERG_LIMIT-1);
+static constexpr int GOLDBERG_LIMIT = (1<<GOLDBERG_BITS);
+static constexpr int GOLDBERG_MASK = (GOLDBERG_LIMIT-1);
 
 #ifndef BADMODEL
 #define BADMODEL 0
 #endif
 
 #ifndef WINGS
-static const int WINGS = (BADMODEL ? 1 : 4);
+static constexpr int WINGS = (BADMODEL ? 1 : 4);
 #endif
 
 typedef array<hpcshape, WINGS+1> hpcshape_animated;
@@ -571,7 +571,7 @@ EX void add_wall(int i, const vector<hyperpoint>& h) {
  */
 
 #if HDR
-static const ld hcrossf7 = 0.620672, hexf7 = 0.378077, tessf7 = 1.090550, hexhexdist7 = 0.566256;
+static constexpr ld hcrossf7 = 0.620672, hexf7 = 0.378077, tessf7 = 1.090550, hexhexdist7 = 0.566256;
 #endif
 
 EX bool scale_used() { return (shmup::on && geometry == gNormal && BITRUNCATED) ? (cheater || autocheat) : true; }

--- a/graph.cpp
+++ b/graph.cpp
@@ -5759,34 +5759,34 @@ EX cfunction current_screen_cfunction() {
 
 #if HDR
 namespace sm {
-  static const int NORMAL = 1;
-  static const int MISSION = 2;
-  static const int HELP = 4;
-  static const int MAP = 8;
-  static const int DRAW = 16;
-  static const int NUMBER = 32;
-  static const int SHMUPCONFIG = 64;
-  static const int OVERVIEW = 128;
-  static const int SIDE = 256;
-  static const int DOTOUR = 512;
-  static const int CENTER = 1024;
-  static const int ZOOMABLE = 4096;
-  static const int TORUSCONFIG = 8192;
-  static const int MAYDARK = 16384;
-  static const int DIALOG_STRICT_X = 32768; // do not interpret dialog clicks outside of the X region
-  static const int EXPANSION = (1<<16);
-  static const int HEXEDIT = (1<<17);
-  static const int VR_MENU = (1<<18); // always show the menu in VR
-  static const int SHOWCURSOR = (1<<19); // despite MAP/DRAW always show the cursor, no panning
-  static const int PANNING = (1<<20); // smooth scrolling works
-  static const int DARKEN = (1<<21); // darken the game background
-  static const int NOSCR = (1<<22); // do not show the game background
-  static const int AUTO_VALUES = (1<<23); // automatic place for values
-  static const int NARROW_LINES = (1<<24); // do make the lines narrower if we needed to reduce width
-  static const int EDIT_BEFORE_WALLS = (1<<25); // mouseover targets before walls
-  static const int EDIT_INSIDE_WALLS = (1<<26); // mouseover targets inside walls
-  static const int DIALOG_WIDE = (1<<27); // make dialogs wide
-  static const int MOUSEAIM = (1<<28); // mouse aiming active here
+  static constexpr int NORMAL = 1;
+  static constexpr int MISSION = 2;
+  static constexpr int HELP = 4;
+  static constexpr int MAP = 8;
+  static constexpr int DRAW = 16;
+  static constexpr int NUMBER = 32;
+  static constexpr int SHMUPCONFIG = 64;
+  static constexpr int OVERVIEW = 128;
+  static constexpr int SIDE = 256;
+  static constexpr int DOTOUR = 512;
+  static constexpr int CENTER = 1024;
+  static constexpr int ZOOMABLE = 4096;
+  static constexpr int TORUSCONFIG = 8192;
+  static constexpr int MAYDARK = 16384;
+  static constexpr int DIALOG_STRICT_X = 32768; // do not interpret dialog clicks outside of the X region
+  static constexpr int EXPANSION = (1<<16);
+  static constexpr int HEXEDIT = (1<<17);
+  static constexpr int VR_MENU = (1<<18); // always show the menu in VR
+  static constexpr int SHOWCURSOR = (1<<19); // despite MAP/DRAW always show the cursor, no panning
+  static constexpr int PANNING = (1<<20); // smooth scrolling works
+  static constexpr int DARKEN = (1<<21); // darken the game background
+  static constexpr int NOSCR = (1<<22); // do not show the game background
+  static constexpr int AUTO_VALUES = (1<<23); // automatic place for values
+  static constexpr int NARROW_LINES = (1<<24); // do make the lines narrower if we needed to reduce width
+  static constexpr int EDIT_BEFORE_WALLS = (1<<25); // mouseover targets before walls
+  static constexpr int EDIT_INSIDE_WALLS = (1<<26); // mouseover targets inside walls
+  static constexpr int DIALOG_WIDE = (1<<27); // make dialogs wide
+  static constexpr int MOUSEAIM = (1<<28); // mouse aiming active here
   }
 #endif
 

--- a/hprint.cpp
+++ b/hprint.cpp
@@ -139,7 +139,7 @@ template<class T, class U> void hread(hstream& hs, map<T,U>& a) {
 template<class C, class C1, class... CS> void hwrite(hstream& hs, const C& c, const C1& c1, const CS&... cs) { hwrite(hs, c); hwrite(hs, c1, cs...); }
 template<class C, class C1, class... CS> void hread(hstream& hs, C& c, C1& c1, CS&... cs) { hread(hs, c); hread(hs, c1, cs...); }
 
-struct hstream_exception : hr_exception { hstream_exception() {} };
+struct hstream_exception : hr_exception {};
 
 struct fhstream : hstream {
   FILE *f;

--- a/hyper.h
+++ b/hyper.h
@@ -550,7 +550,7 @@ public:
 
 using purehookset = hookset<void()>;
 
-static const int NOHINT = -1;
+static constexpr int NOHINT = -1;
 
 typedef function<void()> reaction_t;
 typedef function<bool()> bool_reaction_t;
@@ -664,7 +664,7 @@ struct finalizer {
   ~finalizer() { f(); }
   };
   
-static const int MAXPLAYER = 7;
+static constexpr int MAXPLAYER = 7;
 
 #define DEFAULTCONTROL (multi::players == 1 && !shmup::on && !multi::alwaysuse)
 #define DEFAULTNOR(sym) (DEFAULTCONTROL || multi::notremapped(sym))
@@ -776,7 +776,7 @@ enum orbAction { roMouse, roKeyboard, roCheck, roMouseForce, roMultiCheck, roMul
 #endif
 #define pmodel (pconf.model)
 
-static const int DISTANCE_UNKNOWN = 127;
+static constexpr int DISTANCE_UNKNOWN = 127;
 
 template<class T, class U> int addHook(hookset<T>& m, int prio, U&& hook) {
   return m.add(prio, static_cast<U&&>(hook));
@@ -860,9 +860,9 @@ template<class T, class U> void eliminate_if(vector<T>& data, U pred) {
       data[i] = data.back(), data.pop_back(), i--;
   }
 
-template<class T> array<T, 4> make_array(T a, T b, T c, T d) { array<T,4> x; x[0] = a; x[1] = b; x[2] = c; x[3] = d; return x; }
-template<class T> array<T, 3> make_array(T a, T b, T c) { array<T,3> x; x[0] = a; x[1] = b; x[2] = c; return x; }
-template<class T> array<T, 2> make_array(T a, T b) { array<T,2> x; x[0] = a; x[1] = b; return x; }
+template<class T> constexpr array<T, 4> make_array(T a, T b, T c, T d) { return array<T,4>{a,b,c,d}; }
+template<class T> constexpr array<T, 3> make_array(T a, T b, T c) { return array<T,3>{a,b,c}; }
+template<class T> constexpr array<T, 2> make_array(T a, T b) { return array<T,2>{a,b}; }
 
 // Find in a std::map or std::unordered_map, or return null.
 template<class Map, class Key>
@@ -934,7 +934,7 @@ template<class T> ld binsearch(ld dmin, ld dmax, const T& f, int iterations = 20
   return dmin;
   } 
 
-  static const int max_vec = (1<<14);
+  static constexpr int max_vec = (1<<14);
   extern bool needConfirmationEvenIfSaved();
 
 typedef unsigned long long flagtype;

--- a/inventory.cpp
+++ b/inventory.cpp
@@ -36,8 +36,8 @@ EX namespace inv {
     for(int i=0; i<ittypes; i++) usedup[i] = 0;
     }
   
-  static const int MIRRORED = 1000;
-  static const int TESTMIRRORED = 900;
+  static constexpr int MIRRORED = 1000;
+  static constexpr int TESTMIRRORED = 900;
 
   struct lateextraorb {
     eItem treasure;

--- a/irregular.cpp
+++ b/irregular.cpp
@@ -607,7 +607,7 @@ int hdist(heptagon *h1, heptagon *h2) {
 // - compute celldists for all the cells in these three heptagons, by bfs, based on the 'parent' heptagons adjacent to h
 // - record the computed distances for h, but not for its siblings
 
-static const int NODISTANCE = 2000000000;
+static constexpr int NODISTANCE = 2000000000;
 
 map<heptagon*, heptagon*> last_on_horocycle;
 
@@ -683,7 +683,7 @@ void compute_horocycle(heptagon *alt) {
   heptagon *master = last_on_horocycle[alt];
   // printf("computing horocycle, master distance = %d [M=%p, A=%p]\n", master->alt->distance, hr::voidp(master), hr::voidp(alt));
   
-  static const int LOOKUP = 16;
+  static constexpr int LOOKUP = 16;
   set<heptagon*> hs[LOOKUP];
   hs[0].insert(master);
   set<heptagon*> region;

--- a/items.cpp
+++ b/items.cpp
@@ -460,10 +460,10 @@ EX void countLocalTreasure() {
   }
 
 #if HDR
-static const int NO_TREASURE = 1;
-static const int NO_YENDOR = 2;
-static const int NO_GRAIL = 4;
-static const int NO_LOVE = 8;
+static constexpr int NO_TREASURE = 1;
+static constexpr int NO_YENDOR = 2;
+static constexpr int NO_GRAIL = 4;
+static constexpr int NO_LOVE = 8;
 #endif
 
 EX int gold(int no IS(0)) {

--- a/landlock.cpp
+++ b/landlock.cpp
@@ -619,13 +619,13 @@ template<class T> void generateLandList(T t) {
 
 #if HDR
 namespace lv {
-  static const flagtype appears_in_geom_exp = 1;
-  static const flagtype display_error_message = 2;
-  static const flagtype appears_in_full = 4;
-  static const flagtype appears_in_ptm = 8;
-  static const flagtype display_in_help = 16;
-  static const flagtype one_and_half = 32;
-  static const flagtype switch_to_single = 64;
+  static constexpr flagtype appears_in_geom_exp = 1;
+  static constexpr flagtype display_error_message = 2;
+  static constexpr flagtype appears_in_full = 4;
+  static constexpr flagtype appears_in_ptm = 8;
+  static constexpr flagtype display_in_help = 16;
+  static constexpr flagtype one_and_half = 32;
+  static constexpr flagtype switch_to_single = 64;
   }
 
 struct land_validity_t {

--- a/locations.cpp
+++ b/locations.cpp
@@ -197,10 +197,10 @@ template<class T> void tailored_delete(T* x) {
   delete[] ((char*) (x));
   }
 
-static const struct wstep_t { wstep_t() {} } wstep;
-static const struct wmirror_t { wmirror_t() {}} wmirror;
-static const struct rev_t { rev_t() {} } rev;
-static const struct revstep_t { revstep_t() {}} revstep;
+static constexpr struct wstep_t {} wstep;
+static constexpr struct wmirror_t {} wmirror;
+static constexpr struct rev_t {} rev;
+static constexpr struct revstep_t {} revstep;
 
 extern int hrand(int);
 
@@ -286,7 +286,7 @@ enum hstate { hsOrigin, hsA, hsB, hsError, hsA0, hsA1, hsB0, hsB1, hsC };
 struct cell *createMov(struct cell *c, int d);
 struct heptagon *createStep(struct heptagon *c, int d);
 
-struct cdata_or_heptagon { virtual ~cdata_or_heptagon() {} };
+struct cdata_or_heptagon { virtual ~cdata_or_heptagon() = default; };
 
 struct cdata : cdata_or_heptagon {
   int val[4];
@@ -452,7 +452,7 @@ struct celllister : manual_celllister {
   };
 
 /** \brief translate heptspins to cellwalkers and vice versa */
-static const struct cth_t { cth_t() {}} cth;
+static constexpr struct cth_t {} cth;
 inline heptspin operator+ (cellwalker cw, cth_t) { return heptspin(cw.at->master, cw.spin * DUALMUL, cw.mirrored); }
 inline cellwalker operator+ (heptspin hs, cth_t) { return cellwalker(hs.at->c7, hs.spin / DUALMUL, hs.mirrored); }
 

--- a/mapeditor.cpp
+++ b/mapeditor.cpp
@@ -20,7 +20,7 @@ EX namespace mapeditor {
 
   #if HDR
   enum eShapegroup { sgPlayer, sgMonster, sgItem, sgFloor, sgWall };
-  static const int USERSHAPEGROUPS = 5;
+  static constexpr int USERSHAPEGROUPS = 5;
   #endif
   
   EX color_t dtfill = 0;
@@ -1873,7 +1873,7 @@ EX namespace mapeditor {
   bool coloring;
   color_t colortouse = 0xC0C0C0FFu;
   // fake key sent to change the color
-  static const int COLORKEY = (-10000); 
+  static constexpr int COLORKEY = (-10000); 
 
   EX shiftmatrix drawtrans, drawtransnew;
 

--- a/models.cpp
+++ b/models.cpp
@@ -20,7 +20,7 @@ EX namespace polygonal {
   #endif
 
   #if HDR
-  static const int MSI = 120;
+  static constexpr int MSI = 120;
   #endif
 
   typedef long double xld;

--- a/multi.cpp
+++ b/multi.cpp
@@ -11,10 +11,10 @@ namespace hr {
 EX namespace multi {
 
   #if HDR
-  static const int MAXJOY = 8;
-  static const int MAXBUTTON = 64;
-  static const int MAXAXE = 16;
-  static const int MAXHAT = 4;
+  static constexpr int MAXJOY = 8;
+  static constexpr int MAXBUTTON = 64;
+  static constexpr int MAXAXE = 16;
+  static constexpr int MAXHAT = 4;
   
   struct config {
     char keyaction[512];
@@ -75,8 +75,8 @@ EX namespace multi {
 
   EX double mdx[MAXPLAYER], mdy[MAXPLAYER]; // movement vector for the next move
   
-  static const int CMDS = 15;
-  static const int CMDS_PAN = 11;
+  static constexpr int CMDS = 15;
+  static constexpr int CMDS_PAN = 11;
 
   vector<string> playercmds_shmup = {
     "forward", "backward", "turn left", "turn right",

--- a/nonisotropic.cpp
+++ b/nonisotropic.cpp
@@ -907,13 +907,8 @@ EX namespace nilv {
   #if HDR
   struct mvec : array<int, 3> {
     /** these are in nmHeis */
-    
-    mvec() { }
-  
-    mvec(int x, int y, int z) { 
-      auto& a = *this;
-      a[0] = x; a[1] = y; a[2] = z;
-      }
+    explicit mvec() = default;
+    constexpr explicit mvec(int x, int y, int z) : array{x, y, z} {}
     mvec inverse() {  
       auto& a = *this;
       return mvec(-a[0], -a[1], -a[2]+a[1] * a[0]); 
@@ -925,7 +920,7 @@ EX namespace nilv {
     };
   #endif
 
-  static const mvec mvec_zero = mvec(0, 0, 0);
+  static constexpr mvec mvec_zero = mvec(0, 0, 0);
 
   EX ld nilwidth = 1;
       

--- a/orbgen.cpp
+++ b/orbgen.cpp
@@ -35,36 +35,36 @@ enum eOrbLandRelation {
 #if HDR
 namespace orbgenflags {
   // generates in the given land from 10 treasures, in the classic mode
-  static const int LOCAL10 = 1;
+  static constexpr int LOCAL10 = 1;
   // generates in the Crossroads from 10 treasures, in the classic mode
-  static const int CROSS10 = 2;
+  static constexpr int CROSS10 = 2;
   // generates in other places from 25 treasures, in the classic mode
-  static const int GLOBAL25 = 4;
+  static constexpr int GLOBAL25 = 4;
   // in OSM you get it once at 10 treasures
-  static const int OSM_AT10 = 8;
+  static constexpr int OSM_AT10 = 8;
 
 
   // 'native' functions return this
-  static const int NATIVE = 64;
+  static constexpr int NATIVE = 64;
   // 'local' orb will be also placed in OSM (at 25 treasures); needs LOCAL10
-  static const int OSM_LOCAL25 = 128;
+  static constexpr int OSM_LOCAL25 = 128;
   // 'crossroads' orb will be also placed in OSM (at 50 treasures)
-  static const int OSM_CROSS50 = 256;
+  static constexpr int OSM_CROSS50 = 256;
   // 'crossroads' orb will be also placed in OSM (at 25 treasures)
-  static const int OSM_CROSS25 = 512;
+  static constexpr int OSM_CROSS25 = 512;
   // 'global' orb will be also placed in OSM (at 100 treasures)
-  static const int OSM_GLOBAL100 = 1024;
+  static constexpr int OSM_GLOBAL100 = 1024;
   // do not create in the Crossroads in the tactics mode
-  static const int NO_TACTIC = (1<<11);
+  static constexpr int NO_TACTIC = (1<<11);
   // guest Orb
-  static const int GUEST = (1<<12);
+  static constexpr int GUEST = (1<<12);
   
   // typical combinations
-  static const int S_NATIVE = LOCAL10 | CROSS10 | GLOBAL25 | NATIVE;
-  static const int S_GUEST  = LOCAL10 | OSM_AT10 | GUEST;
-  static const int S_YENDOR = S_NATIVE | OSM_LOCAL25 | OSM_CROSS50 | OSM_GLOBAL100 | NO_TACTIC;
-  static const int S_NAT_NT = S_NATIVE | NO_TACTIC;
-  static const int S_NA_O25 = S_NATIVE | OSM_CROSS25;
+  static constexpr int S_NATIVE = LOCAL10 | CROSS10 | GLOBAL25 | NATIVE;
+  static constexpr int S_GUEST  = LOCAL10 | OSM_AT10 | GUEST;
+  static constexpr int S_YENDOR = S_NATIVE | OSM_LOCAL25 | OSM_CROSS50 | OSM_GLOBAL100 | NO_TACTIC;
+  static constexpr int S_NAT_NT = S_NATIVE | NO_TACTIC;
+  static constexpr int S_NA_O25 = S_NATIVE | OSM_CROSS25;
   }
 
 struct orbinfo {

--- a/pattern2.cpp
+++ b/pattern2.cpp
@@ -628,20 +628,20 @@ EX namespace patterns {
     PAT_SINGLETYPE = 't'
     };  
 
-  static const int SPF_ROT = 1;
-  static const int SPF_SYM01 = 2;
-  static const int SPF_SYM02 = 4;
-  static const int SPF_SYM03 = 8;
-  static const int SPF_CHANGEROT = 16;
-  static const int SPF_TWOCOL = 32;
-  static const int SPF_EXTRASYM = 64;
-  static const int SPF_ALTERNATE = 128;
-  static const int SPF_FOOTBALL = 256;
-  static const int SPF_FULLSYM = 512;
-  static const int SPF_DOCKS = 1024;
-  static const int SPF_NO_SUBCODES = 2048;
+  static constexpr int SPF_ROT = 1;
+  static constexpr int SPF_SYM01 = 2;
+  static constexpr int SPF_SYM02 = 4;
+  static constexpr int SPF_SYM03 = 8;
+  static constexpr int SPF_CHANGEROT = 16;
+  static constexpr int SPF_TWOCOL = 32;
+  static constexpr int SPF_EXTRASYM = 64;
+  static constexpr int SPF_ALTERNATE = 128;
+  static constexpr int SPF_FOOTBALL = 256;
+  static constexpr int SPF_FULLSYM = 512;
+  static constexpr int SPF_DOCKS = 1024;
+  static constexpr int SPF_NO_SUBCODES = 2048;
 
-  static const int SPF_SYM0123 = SPF_SYM01 | SPF_SYM02 | SPF_SYM03;
+  static constexpr int SPF_SYM0123 = SPF_SYM01 | SPF_SYM02 | SPF_SYM03;
 
   struct patterninfo {
     int id;

--- a/racing.cpp
+++ b/racing.cpp
@@ -26,8 +26,8 @@ int TWIDTH;
 
 EX ld race_advance = 0;
 
-static const int LENGTH = 250;
-static const int DROP = 1;
+static constexpr int LENGTH = 250;
+static constexpr int DROP = 1;
 
 EX int ghosts_to_show = 5;
 EX int ghosts_to_save = 10;
@@ -59,7 +59,7 @@ uchar angle_to_uchar(ld x) { return frac_to_uchar(x / TAU); }
 ld uchar_to_frac(uchar x) { return x / 256.; }
 transmatrix spin_uchar(uchar x) { return spin(uchar_to_frac(x) * TAU); }
 
-static const ld distance_multiplier = 4;
+static constexpr ld distance_multiplier = 4;
 
 struct ghostmoment {
   int step;

--- a/raycaster.cpp
+++ b/raycaster.cpp
@@ -46,7 +46,7 @@ EX ld minstep = .001;
 
 EX ld reflect_val = 0;
 
-static const int NO_LIMIT = 999999;
+static constexpr int NO_LIMIT = 999999;
 
 EX ld hard_limit = NO_LIMIT;
 
@@ -186,11 +186,11 @@ struct raycaster : glhr::GLprogram {
 #ifdef GLES_ONLY
 bool m_via_texture = false;
 bool wall_via_texture = false;
-static const bool can_via_texture = false; /* textures are not precise enough ): */
+static constexpr bool can_via_texture = false; /* textures are not precise enough ): */
 #else
 bool m_via_texture = true;
 bool wall_via_texture = true;
-static const bool can_via_texture = true;
+static constexpr bool can_via_texture = true;
 #endif
 
 

--- a/rogueviz/dhrg/dhrg-utils.cpp
+++ b/rogueviz/dhrg/dhrg-utils.cpp
@@ -5,7 +5,7 @@ namespace dhrg {
 
 struct progressbar : indenter_finish {
   string name;
-  static const int PBSIZE = 64;
+  static constexpr int PBSIZE = 64;
   int step = -1, total, drawat = 0, count = -1;
   
   void operator ++ (int) { 

--- a/rogueviz/dhrg/dhrg.h
+++ b/rogueviz/dhrg/dhrg.h
@@ -12,10 +12,10 @@ using namespace hr;
 typedef long long ll;
 
 #ifndef BOXSIZE
-static const int BOXSIZE = 32;
+static constexpr int BOXSIZE = 32;
 #endif
-static const int MAXDIST = (2*BOXSIZE);
-static const int SETS = 4;
+static constexpr int MAXDIST = (2*BOXSIZE);
+static constexpr int SETS = 4;
 
 struct segment;
 

--- a/rogueviz/fifteen.cpp
+++ b/rogueviz/fifteen.cpp
@@ -11,7 +11,7 @@ namespace hr {
 
 EX namespace fifteen {
 
-static const int Empty = 0;
+static constexpr int Empty = 0;
 
 struct celldata {
   int target, targetdir;

--- a/rogueviz/impossible-ring.cpp
+++ b/rogueviz/impossible-ring.cpp
@@ -20,11 +20,11 @@ struct iring {
 
   geometry_information *icgi;
 
-  static const int frames = 32;
+  static constexpr int frames = 32;
   
-  static const int cols = 256;
+  static constexpr int cols = 256;
 
-  static const int steps = 2048;    
+  static constexpr int steps = 2048;    
 
   array<array<hpcshape, cols>, frames> ptriangle[2];
 

--- a/rogueviz/leastsquare.cpp
+++ b/rogueviz/leastsquare.cpp
@@ -61,7 +61,7 @@ template<size_t N> struct leastsquare_solution : public array<val, N> {
 template<size_t N> struct leastsquare_solver {
   array<array<val, N>, N> toinvert;
   array<val, N> Xty;
-  static const int iN = N;
+  static constexpr int iN = N;
 
   leastsquare_solver() {
     for(int y=0; y<iN; y++) Xty[y] = 0;

--- a/rogueviz/platformer.cpp
+++ b/rogueviz/platformer.cpp
@@ -375,7 +375,7 @@ static double gtime = 0;
 
 double vel_x = 0, vel_y = 0;
 
-static const double grav = 0.1;
+static constexpr double grav = 0.1;
 
 bool map_on = false;
 

--- a/rogueviz/rogueviz.h
+++ b/rogueviz/rogueviz.h
@@ -54,7 +54,7 @@ namespace rogueviz {
 
   edgetype *add_edgetype(const string& name);
   
-  static const unsigned DEFAULT_COLOR = 0x471293B5;
+  static constexpr unsigned DEFAULT_COLOR = 0x471293B5;
 
   extern edgetype default_edgetype;
   
@@ -255,7 +255,7 @@ function<void(presmode)> roguevizslide_action(char c, const T& t, const U& act) 
   void use_angledir(presmode mode, bool reset);
   void slide_error(presmode mode, string s);
 
-  static const flagtype LATEX_COLOR = 1;
+  static constexpr flagtype LATEX_COLOR = 1;
   
   void show_latex(presmode mode, string s);
   void dialog_add_latex(string s, color_t color, int size = 100, flagtype flag = 0);

--- a/rogueviz/som/kohonen.h
+++ b/rogueviz/som/kohonen.h
@@ -12,11 +12,11 @@ namespace kohonen {
 
 typedef vector<double> kohvec;
 
-static const flagtype KS_ROGUEVIZ = 1;
-static const flagtype KS_NEURONS = 2;
-static const flagtype KS_DISPERSION = 4;
-static const flagtype KS_SAMPLES = 8;
-static const flagtype KS_NEURONS_INI = 16;
+static constexpr flagtype KS_ROGUEVIZ = 1;
+static constexpr flagtype KS_NEURONS = 2;
+static constexpr flagtype KS_DISPERSION = 4;
+static constexpr flagtype KS_SAMPLES = 8;
+static constexpr flagtype KS_NEURONS_INI = 16;
 
 extern flagtype state;
 
@@ -139,7 +139,7 @@ struct manidata {
   vector<pair<int, int> > edges;
   };
 
-static const int MCOUNT = 12;
+static constexpr int MCOUNT = 12;
 
 extern vector<string> catnames;
 
@@ -149,7 +149,7 @@ ld evaluate_measure(manidata& emb, manidata& orig, vector<int>& mapp, vector<pai
 
 }
 
-static const string som_test_dir = "results/";
+static constexpr string som_test_dir = "results/";
 }
 
 

--- a/rug.cpp
+++ b/rug.cpp
@@ -476,7 +476,7 @@ EX void buildTorusRug() {
         
     r->valid = true;
     
-    static const int X = 100003; // a prime
+    static constexpr int X = 100003; // a prime
     auto gluefun = [] (ld z) { return int(frac(z + .5/X) * X); };
     auto p = make_pair(gluefun(h[0]), gluefun(h[1]));
     auto& r2 = glues[p];
@@ -1374,7 +1374,7 @@ EX void actDraw() {
 
 int besti;
 
-static const ld RADAR_INF = 1e12;
+static constexpr ld RADAR_INF = 1e12;
 ld radar_distance = RADAR_INF;
 
 EX shiftpoint gethyper(ld x, ld y) {

--- a/rulegen.cpp
+++ b/rulegen.cpp
@@ -59,39 +59,39 @@ EX int states_premini = 0;
 
 #if HDR
 /** change some flags -- they usually make it worse */
-static const flagtype w_numerical = Flag(1); /*< build trees numerically */
-static const flagtype w_near_solid = Flag(2); /*< solid's pre-parent is also solid */
-static const flagtype w_no_shortcut = Flag(3); /*< generate no shortcuts */
-static const flagtype w_no_restart = Flag(4); /*< do not restart at powers of two */
-static const flagtype w_no_sidecache = Flag(5); /*< do not cache get_side */
-static const flagtype w_no_relative_distance = Flag(6); /*< do not build relative distances into codes */
-static const flagtype w_examine_once = Flag(7); /*< restart after first conflict found in analysis */
-static const flagtype w_examine_all = Flag(8); /*< focus on all conflicts found in analysis even if we know them */
-static const flagtype w_conflict_all = Flag(9); /*< full extension in case of conflicts */
-static const flagtype w_parent_always = Flag(10); /*< always consider the full parent rule */
-static const flagtype w_parent_reverse = Flag(11); /*< reverse paths in parent_dir */
-static const flagtype w_parent_side = Flag(12); /*< allow side paths in parent_dir */
-static const flagtype w_parent_never = Flag(13); /*< never consider the full parent rule */
-static const flagtype w_always_clean = Flag(14); /*< restart following phases after any distance errors */
-static const flagtype w_single_origin = Flag(15); /*< consider only one origin */
-static const flagtype w_slow_side = Flag(16); /*< do not try get_side optimization */
-static const flagtype w_bfs = Flag(17); /*< compute distances using BFS */
-static const flagtype w_numerical_fix = Flag(18); /*< when doing numerical, find out filled vertices */
-static const flagtype w_known_structure = Flag(19); /*< do flagless first, then use the known distances from there (handled in ruletest) */
-static const flagtype w_known_distances = Flag(20); /*< with, use the actual distances */
-static const flagtype w_no_smart_shortcuts = Flag(21); /*< disable the 'smart shortcut' optimization */
-static const flagtype w_less_smart_retrace = Flag(22); /*< stop early when examining smart shortcut retraction */
-static const flagtype w_less_smart_advance = Flag(23); /*< stop early when examining smart shortcut advancement */
-static const flagtype w_no_queued_extensions = Flag(24); /*< consider extensions one by one */
-static const flagtype w_no_branch_skipping = Flag(24); /*< do not skip branches */
+static constexpr flagtype w_numerical = Flag(1); /*< build trees numerically */
+static constexpr flagtype w_near_solid = Flag(2); /*< solid's pre-parent is also solid */
+static constexpr flagtype w_no_shortcut = Flag(3); /*< generate no shortcuts */
+static constexpr flagtype w_no_restart = Flag(4); /*< do not restart at powers of two */
+static constexpr flagtype w_no_sidecache = Flag(5); /*< do not cache get_side */
+static constexpr flagtype w_no_relative_distance = Flag(6); /*< do not build relative distances into codes */
+static constexpr flagtype w_examine_once = Flag(7); /*< restart after first conflict found in analysis */
+static constexpr flagtype w_examine_all = Flag(8); /*< focus on all conflicts found in analysis even if we know them */
+static constexpr flagtype w_conflict_all = Flag(9); /*< full extension in case of conflicts */
+static constexpr flagtype w_parent_always = Flag(10); /*< always consider the full parent rule */
+static constexpr flagtype w_parent_reverse = Flag(11); /*< reverse paths in parent_dir */
+static constexpr flagtype w_parent_side = Flag(12); /*< allow side paths in parent_dir */
+static constexpr flagtype w_parent_never = Flag(13); /*< never consider the full parent rule */
+static constexpr flagtype w_always_clean = Flag(14); /*< restart following phases after any distance errors */
+static constexpr flagtype w_single_origin = Flag(15); /*< consider only one origin */
+static constexpr flagtype w_slow_side = Flag(16); /*< do not try get_side optimization */
+static constexpr flagtype w_bfs = Flag(17); /*< compute distances using BFS */
+static constexpr flagtype w_numerical_fix = Flag(18); /*< when doing numerical, find out filled vertices */
+static constexpr flagtype w_known_structure = Flag(19); /*< do flagless first, then use the known distances from there (handled in ruletest) */
+static constexpr flagtype w_known_distances = Flag(20); /*< with, use the actual distances */
+static constexpr flagtype w_no_smart_shortcuts = Flag(21); /*< disable the 'smart shortcut' optimization */
+static constexpr flagtype w_less_smart_retrace = Flag(22); /*< stop early when examining smart shortcut retraction */
+static constexpr flagtype w_less_smart_advance = Flag(23); /*< stop early when examining smart shortcut advancement */
+static constexpr flagtype w_no_queued_extensions = Flag(24); /*< consider extensions one by one */
+static constexpr flagtype w_no_branch_skipping = Flag(24); /*< do not skip branches */
 
 /* for 3D honeycombs */
-static const flagtype w_skip_transducers = Flag(32); /*< skip the transducer test */
-static const flagtype w_skip_transducer_loops = Flag(33); /*< skip loops during the transducer test */
-static const flagtype w_skip_transducer_terminate = Flag(34); /*< skip termination during the transducer test */
-static const flagtype w_r3_all_errors = Flag(35); /*< consider all errors for R3 */
-static const flagtype w_r3_no_road_shortcuts = Flag(36); /*< consider all errors for R3 */
-static const flagtype w_ignore_transducer_dist = Flag(37); /*< ignore distance errors while testing the transducers */
+static constexpr flagtype w_skip_transducers = Flag(32); /*< skip the transducer test */
+static constexpr flagtype w_skip_transducer_loops = Flag(33); /*< skip loops during the transducer test */
+static constexpr flagtype w_skip_transducer_terminate = Flag(34); /*< skip termination during the transducer test */
+static constexpr flagtype w_r3_all_errors = Flag(35); /*< consider all errors for R3 */
+static constexpr flagtype w_r3_no_road_shortcuts = Flag(36); /*< consider all errors for R3 */
+static constexpr flagtype w_ignore_transducer_dist = Flag(37); /*< ignore distance errors while testing the transducers */
 #endif
 
 /** these control the output */
@@ -1160,12 +1160,12 @@ struct treestate {
   vector<pair<int, int>> possible_parents;
   };
 
-static const int C_IGNORE = 0;
-static const int C_CHILD = 1;
-static const int C_UNCLE = 2;
-static const int C_EQUAL = 4;
-static const int C_NEPHEW = 6;  
-static const int C_PARENT = 8;
+static constexpr int C_IGNORE = 0;
+static constexpr int C_CHILD = 1;
+static constexpr int C_UNCLE = 2;
+static constexpr int C_EQUAL = 4;
+static constexpr int C_NEPHEW = 6;  
+static constexpr int C_PARENT = 8;
 #endif
 
 EX vector<treestate> treestates;
@@ -1445,10 +1445,10 @@ vector<twalker> cq;
 
 #if HDR
 /* special codes */
-static const int DIR_UNKNOWN = -1;
-static const int DIR_LEFT = -4;
-static const int DIR_RIGHT = -5;
-static const int DIR_PARENT = -6;
+static constexpr int DIR_UNKNOWN = -1;
+static constexpr int DIR_LEFT = -4;
+static constexpr int DIR_RIGHT = -5;
+static constexpr int DIR_PARENT = -6;
 #endif
 
 vector<int> gen_rule(twalker cwmain, int id) {

--- a/savemem.cpp
+++ b/savemem.cpp
@@ -9,7 +9,7 @@
 namespace hr {
 
 #if HDR
-static const int PSEUDOKEY_MEMORY = 16397;
+static constexpr int PSEUDOKEY_MEMORY = 16397;
 #endif
 
 EX bool memory_saving_mode = true;
@@ -17,7 +17,7 @@ EX bool memory_saving_mode = true;
 EX bool show_memory_warning = true;
 EX bool ignored_memory_warning;
 
-static const int LIM = 150;
+static constexpr int LIM = 150;
 
 EX heptagon *last_cleared;
 

--- a/shmup.cpp
+++ b/shmup.cpp
@@ -720,7 +720,7 @@ bool noncrashable(monster *m, monster *by) {
 int bulltime[MAXPLAYER];
 
 // set to P_MIRRORWALL to allow the PCs to go through mirrors
-static const int reflectflag = P_MIRRORWALL;
+static constexpr int reflectflag = P_MIRRORWALL;
 
 void movePlayer(monster *m, int delta) {
 

--- a/sky.cpp
+++ b/sky.cpp
@@ -139,7 +139,7 @@ void compute_skyvertices(const vector<sky_item>& sky) {
         transmatrix T1 = unshift(si.T);
         hyperpoint ci = kleinize(get_corner_position(c, i, 3));
         hyperpoint cj = kleinize(get_corner_position(c, j, 3));
-        static const int prec = 8;
+        static constexpr int prec = 8;
         ci = (ci - C0)/prec;
         cj = (cj - C0)/prec;
         glhr::colored_vertex vs[prec+1][prec+1], vh[prec+1][prec+1];
@@ -194,7 +194,7 @@ void compute_skyvertices(const vector<sky_item>& sky) {
     
     for(int i=0; i<c->type; i++) {
       
-      static const int prec = 2; 
+      static constexpr int prec = 2; 
 
       if(1) {
         cellwalker cw0(c, i);

--- a/system.cpp
+++ b/system.cpp
@@ -11,30 +11,30 @@ namespace hr {
 #if HDR
 /** \brief This namespace has constants used as parameters in functions such as restart_game and wrongmode. */
 namespace rg {
-  static const char nothing = 0;
-  static const char peace = 'P';
-  static const char inv = 'i';
-  static const char chaos = 'C';
-  static const char tactic = 't';
-  static const char tour = 'T';
-  static const char yendor = 'y';
-  static const char shmup = 's';
-  static const char randpattern = 'r';
-  static const char princess = 'p';
-  static const char daily = 'd';
-  static const char daily_off = 'D';
-  static const char racing = 'R';
-  static const char dualmode = 'U';
-  static const char heptagons = '7';
+  static constexpr char nothing = 0;
+  static constexpr char peace = 'P';
+  static constexpr char inv = 'i';
+  static constexpr char chaos = 'C';
+  static constexpr char tactic = 't';
+  static constexpr char tour = 'T';
+  static constexpr char yendor = 'y';
+  static constexpr char shmup = 's';
+  static constexpr char randpattern = 'r';
+  static constexpr char princess = 'p';
+  static constexpr char daily = 'd';
+  static constexpr char daily_off = 'D';
+  static constexpr char racing = 'R';
+  static constexpr char dualmode = 'U';
+  static constexpr char heptagons = '7';
   
   /** \brief wrongmode only -- marks 'global' achievements not related to the current mode */
-  static const char global = 'x'; 
+  static constexpr char global = 'x'; 
   /** \brief wrongmode only -- change vid.scfg.players then restart_game(rg::nothing) instead */
-  static const char multi = 'm';
+  static constexpr char multi = 'm';
   /** \brief wrongmode only -- mark achievements for special geometries/variations, this automatically marks the expected land_structure as lsSingle */
-  static const char special_geometry = 'g';
+  static constexpr char special_geometry = 'g';
   /** \brief wrongmode only -- mark achievements for special geometries/variations */
-  static const char special_geometry_nicewalls = 'G';
+  static constexpr char special_geometry_nicewalls = 'G';
   }
 #endif
 

--- a/textures.cpp
+++ b/textures.cpp
@@ -566,7 +566,7 @@ void texture_config::mark_triangles() {
       }
   }
 
-static const auto current_texture_parameters = tie(geometry, variation, patterns::whichPattern, patterns::subpattern_flags, pmodel, pconf.scale, pconf.alpha);
+static constexpr auto current_texture_parameters = tie(geometry, variation, patterns::whichPattern, patterns::subpattern_flags, pmodel, pconf.scale, pconf.alpha);
 
 void texture_config::clear_texture_map() {
   texture_map.clear();

--- a/tour.cpp
+++ b/tour.cpp
@@ -60,19 +60,19 @@ namespace LEGAL {
   }
 
 /** \brief when Enter pressed while showing the text, skip to the next slide immediately */
-static const flagtype QUICKSKIP=8;
+static constexpr flagtype QUICKSKIP=8;
 /** \brief The final slide. Shows where the presentation ends */
-static const flagtype FINALSLIDE=16;
+static constexpr flagtype FINALSLIDE=16;
 /** \brief Pressing Enter while in another geometry should change slides immediately */
-static const flagtype QUICKGEO=32;
+static constexpr flagtype QUICKGEO=32;
 /** \brief This slide should be displayed in sidescreen mode */
-static const flagtype SIDESCREEN = 64;
+static constexpr flagtype SIDESCREEN = 64;
 /** \brief When changing geometries, show the name of the slide, instead of the current land */
-static const flagtype USE_SLIDE_NAME = 128;
+static constexpr flagtype USE_SLIDE_NAME = 128;
 /** \brief do not display any help line */
-static const flagtype NOTITLE = 256;
+static constexpr flagtype NOTITLE = 256;
 /** \brief always display the text, even if going back or texts are disabled */
-static const flagtype ALWAYS_TEXT = 256;
+static constexpr flagtype ALWAYS_TEXT = 256;
 #endif
 
 EX vector<reaction_t> restorers;

--- a/util.cpp
+++ b/util.cpp
@@ -573,8 +573,8 @@ EX string available_constants() {
 
 #if HDR
 struct bignum {
-  static const int BASE = 1000000000;
-  static const long long BASE2 = BASE * (long long)BASE;
+  static constexpr int BASE = 1000000000;
+  static constexpr long long BASE2 = BASE * (long long)BASE;
   vector<int> digits;
   bignum() {}
   bignum(int i) : digits() { digits.push_back(i); }


### PR DESCRIPTION
Since we require C++11, most of these consts can be constexpr.

Two `static const ld` remain non-compile-time-evaluable because they depend on the runtime `log` function. One `static const cld` remains non-compile-time because `std::complex<T>` doesn't become constexpr until C++14.