### PR TITLE
Calculate tidalsize before using it in mouseovers.

### DIFF
--- a/help.cpp
+++ b/help.cpp
@@ -881,6 +881,7 @@ EX void describeMouseover() {
       if(shmup::on)
         out += " (" + its(c->landparam)+")";
       else {
+        calcTidalPhase();
         bool b = c->landparam >= tide[(turncount-1) % tidalsize];
         int t = 1;
         for(; t < 1000 && b == (c->landparam >= tide[(turncount+t-1) % tidalsize]); t++) ;


### PR DESCRIPTION
This way the game doesn't immediately crash when restoring a save in tidal areas.