### PR TITLE
Record World Turtle kills.

### DIFF
--- a/system.cpp
+++ b/system.cpp
@@ -593,9 +593,7 @@ EX void applyBoxes() {
   
   for(int i=0; i<43; i++) {
     if(loading) kills[i] = 0;
-    bool fake = 
-      i == moLesserM || i == moNone || i == moWolfMoved || i == moTentacletail ||
-      i == moIvyNext;
+    bool fake = (i == moREMOVED || i == moLesserM || i == moTentacletail);
     if(i == moWormtail) applyBoxM(moCrystalSage);
     else if(i == moWormwait) applyBoxM(moFireFairy);
     else if(i == moTentacleEscaping) applyBoxM(moMiner);
@@ -603,6 +601,7 @@ EX void applyBoxes() {
     else if(i == moTentaclewait) applyBoxOrb(itOrbThorns);
     else if(i == moGreater) applyBoxOrb(itOrbDragon);
     else if(i == moGreaterM) applyBoxOrb(itOrbIllusion);
+    else if(i == moWolfMoved) applyBoxM(moWorldTurtle);
     else applyBoxM(eMonster(i), fake);
     }
     


### PR DESCRIPTION
Clean up "fake" monsters:
* moNone is used for melted walls.
* moIvyNext is actually tracked.
* moWolfMoved is newly used for World Turtles.
* moREMOVED isn't used.