### PR TITLE
Record the ranged weapons' state in the savefile

### DIFF
--- a/system.cpp
+++ b/system.cpp
@@ -444,7 +444,7 @@ EX namespace scores {
 /** \brief the amount of boxes reserved for each hr::score item */
 #define MAXBOX 500
 /** \brief currently used boxes in hr::score */
-#define POSSCORE 411
+#define POSSCORE 412
 /** \brief a struct to keep local score from an earlier game */
 struct score {
   /** \brief version used */
@@ -948,6 +948,7 @@ EX void applyBoxes() {
   list_invorb();
 
   applyBoxNum(items[itCrossbow]);
+  applyBoxNum(items[itRevolver]);
 
   if(POSSCORE != boxid) printf("ERROR: %d boxes\n", boxid);
   if(isize(invorb)) { println(hlog, "ERROR: Orbs not taken into account"); exit(1); }

--- a/system.cpp
+++ b/system.cpp
@@ -444,7 +444,7 @@ EX namespace scores {
 /** \brief the amount of boxes reserved for each hr::score item */
 #define MAXBOX 500
 /** \brief currently used boxes in hr::score */
-#define POSSCORE 410
+#define POSSCORE 411
 /** \brief a struct to keep local score from an earlier game */
 struct score {
   /** \brief version used */
@@ -946,6 +946,8 @@ EX void applyBoxes() {
 
   applyBoxOrb(itOrbFish);
   list_invorb();
+
+  applyBoxNum(items[itCrossbow]);
 
   if(POSSCORE != boxid) printf("ERROR: %d boxes\n", boxid);
   if(isize(invorb)) { println(hlog, "ERROR: Orbs not taken into account"); exit(1); }


### PR DESCRIPTION
For the crossbow, record the reload timer.
For the revolver, record the amount of ammunition.