### PR TITLE
Draw player's hair above their face

### DIFF
--- a/polygons.cpp
+++ b/polygons.cpp
@@ -1503,7 +1503,7 @@ void geometry_information::prepare_shapes() {
   bshape(shHood, PPR::MONSTER_HAT0, scalefactor, 123);
   bshape(shPirateHood, PPR::MONSTER_HAT0, scalefactor, 125);
   bshape(shEyepatch, PPR::MONSTER_HAT1, scalefactor, 126);
-  bshape(shPHead, PPR::MONSTER_HEAD, scalefactor, 127);
+  bshape(shPHead, PPR::MONSTER_HAIR, scalefactor, 127);
   shGolemhead = shDisk; shGolemhead.prio = PPR::MONSTER_HEAD;
   bshape(shFemaleHair, PPR::MONSTER_HAIR, scalefactor, 128);
   bshape(shWitchHair, PPR::MONSTER_HAIR, scalefactor, 129);


### PR DESCRIPTION
The polygon for default player character's hair is called `shPHead`. I believe this has led to an oversight where the polygon is enqueued on layer/priority `MONSTER_HEAD`, which is actually below `MONSTER_FACE`, causing their face to be rendered over their hair. If that layering was intentional, please ignore this PR.

Left is original, right is after switching `shPHead` to layer/priority `MONSTER_HAIR`.
![image](https://github.com/zenorogue/hyperrogue/assets/96886300/36bd39af-82f2-4481-9448-87a02438ab02)
