### PR TITLE
Change some walls' electrical properties.

### DIFF
--- a/complex.cpp
+++ b/complex.cpp
@@ -221,6 +221,8 @@ EX namespace elec {
         return isElectricLand(c) ? ecConductor : ecGrounded; 
     if(c->wall == waBigTree || c->wall == waSmallTree)
         return ecGrounded;
+    if(among(c->wall, waRed1, waRed2, waRed3, waRubble, waDeadfloor2))
+        return ecIsolator;
     if(c->wall == waBarrier)
       return ecIsolator;
     if(c->wall == waChasm)

--- a/complex.cpp
+++ b/complex.cpp
@@ -215,7 +215,7 @@ EX namespace elec {
     if(c->wall == waSea || c->wall == waGrounded) return ecGrounded;
     if(c->wall == waSandstone || c->wall == waDeadTroll || 
       c->wall == waDeadTroll2 || 
-      among(c->wall, waBigTree, waSmallTree, waExplosiveBarrel, waRed1, waRed2, waRed3) ||
+      c->wall == waExplosiveBarrel ||
       c->wall == waVinePlant ||
       c->wall == waMetal || isAlchAny(c)) 
         return isElectricLand(c) ? ecConductor : ecGrounded; 

--- a/complex.cpp
+++ b/complex.cpp
@@ -219,6 +219,8 @@ EX namespace elec {
       c->wall == waVinePlant ||
       c->wall == waMetal || isAlchAny(c)) 
         return isElectricLand(c) ? ecConductor : ecGrounded; 
+    if(c->wall == waBigTree || c->wall == waSmallTree)
+        return ecGrounded;
     if(c->wall == waBarrier)
       return ecIsolator;
     if(c->wall == waChasm)


### PR DESCRIPTION
Implemented first two items from the +11 #suggestions post by `A human`: https://discord.com/channels/540092734300618753/550649263772794890/1216468280785506334

Trees changed from conductive to grounded.
Red rock changed from conductive to insulative.
Rubble changed from neutral to insulative.

This will significantly affect Eclectic City, and should have no significant effect on other lands.