### PR TITLE
Record fuel collected and space rocks killed.

### DIFF
--- a/system.cpp
+++ b/system.cpp
@@ -447,7 +447,7 @@ EX namespace scores {
 /** \brief the amount of boxes reserved for each hr::score item */
 #define MAXBOX 500
 /** \brief currently used boxes in hr::score */
-#define POSSCORE 412
+#define POSSCORE 414
 /** \brief a struct to keep local score from an earlier game */
 struct score {
   /** \brief version used */
@@ -954,6 +954,8 @@ EX void applyBoxes() {
 
   applyBoxNum(items[itCrossbow]);
   applyBoxNum(items[itRevolver]);
+  applyBoxNum(items[itAsteroid]);
+  applyBoxM(moAsteroid);
 
   if(POSSCORE != boxid) printf("ERROR: %d boxes\n", boxid);
   if(isize(invorb)) { println(hlog, "ERROR: Orbs not taken into account"); exit(1); }


### PR DESCRIPTION
Now that Space Rocks can be included in a custom landset, a player can save the game while they have fuel and space rock "kills".