### PR TITLE
Fix Mac Build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # This Makefile works for Mac OS X (El Capitan), MinGW, and Linux.
 #
 # For Mac OS X:
-#   Run "brew install sdl" to install SDL in /usr/local.
+#   Run "brew install sdl" to install SDL in $(HOMEBREW_PREFIX).
 #   Run "brew install sdl_gfx".
 #   Run "brew install sdl_mixer".
 #   Run "brew install sdl_ttf".
@@ -13,7 +13,7 @@
 #   Run "make" to build HyperRogue as ./hyperrogue.exe.
 #
 # For Ubuntu Linux:
-#   Run "sudo apt-get install libsdl-dev" to install SDL in /usr/local.
+#   Run "sudo apt-get install libsdl-dev" to install SDL in $(HOMEBREW_PREFIX).
 #   Run "make" to build HyperRogue as ./hyperrogue.
 
 
@@ -68,9 +68,10 @@ ifeq (${OS},mingw)
 endif
 
 ifeq (${OS},osx)
-  CXXFLAGS_EARLY += -DMAC -I/usr/local/include
+  HOMEBREW_PREFIX := $(shell brew --prefix)
+  CXXFLAGS_EARLY += -DMAC -I$(HOMEBREW_PREFIX)/include
   EXE_EXTENSION :=
-  LDFLAGS_EARLY += -L/usr/local/lib
+  LDFLAGS_EARLY += -L$(HOMEBREW_PREFIX)/lib
   LDFLAGS_GL := -framework AppKit -framework OpenGL
   LDFLAGS_GLEW := -lGLEW
   LDFLAGS_PNG := -lpng

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,6 @@
 #   Run `brew install sdl12-compat sdl_gfx sdl_mixer sdl_ttf glew`
 #   Run "make" to build HyperRogue as ./hyperrogue.
 #
-#   As a workaround to a build error, macOS users will have 
-#   to manually edit `$(brew --prefix)/include/SDL/SDL_gfxPrimitives.h` at
-#   line 38 to use quote include.
-#
 # For MSYS2 and MinGW-w64:
 #   You might need to run commands such as "pacman -S mingw-w64-x86_64-SDL"
 #   to install SDL and other required libraries.
@@ -70,7 +66,7 @@ endif
 
 ifeq (${OS},osx)
   HOMEBREW_PREFIX := $(shell brew --prefix)
-  CXXFLAGS_EARLY += -DMAC -I$(HOMEBREW_PREFIX)/include
+  CXXFLAGS_EARLY += -DMAC -I$(HOMEBREW_PREFIX)/include -I$(HOMEBREW_PREFIX)/include/SDL
   EXE_EXTENSION :=
   LDFLAGS_EARLY += -L$(HOMEBREW_PREFIX)/lib
   LDFLAGS_GL := -framework AppKit -framework OpenGL

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,15 @@
 # This Makefile works for Mac OS X (El Capitan), MinGW, and Linux.
+# 
+# Environmental vairables:
+#   If you want to build with Glew, set
+#     HYPERROGUE_USE_GLEW=1
+#   If you want to use libpng, set
+#     HYPERROGUE_USE_PNG=1
 #
 # For Mac OS X:
-#   Run `brew install sdl12-compat sdl_gfx sdl_mixer sdl_ttf glew`
-#   Run "make" to build HyperRogue as ./hyperrogue.
+#   Run `brew install sdl12-compat sdl_gfx sdl_mixer sdl_ttf`
+#   Run `brew install glew libpng` to install the optional dependencies
+#   Run `make` to build HyperRogue as `./hyperrogue`.
 #
 # For MSYS2 and MinGW-w64:
 #   You might need to run commands such as "pacman -S mingw-w64-x86_64-SDL"

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 # This Makefile works for Mac OS X (El Capitan), MinGW, and Linux.
 #
 # For Mac OS X:
-#   Run "brew install sdl" to install SDL in $(HOMEBREW_PREFIX).
-#   Run "brew install sdl_gfx".
-#   Run "brew install sdl_mixer".
-#   Run "brew install sdl_ttf".
+#   Run `brew install sdl12-compat sdl_gfx sdl_mixer sdl_ttf glew`
 #   Run "make" to build HyperRogue as ./hyperrogue.
+#
+#   As a workaround to a build error, macOS users will have 
+#   to manually edit `$(brew --prefix)/include/SDL/SDL_gfxPrimitives.h` at
+#   line 38 to use quote include.
 #
 # For MSYS2 and MinGW-w64:
 #   You might need to run commands such as "pacman -S mingw-w64-x86_64-SDL"
@@ -13,7 +14,7 @@
 #   Run "make" to build HyperRogue as ./hyperrogue.exe.
 #
 # For Ubuntu Linux:
-#   Run "sudo apt-get install libsdl-dev" to install SDL in $(HOMEBREW_PREFIX).
+#   Run "sudo apt-get install libsdl-dev" to install SDL in /usr/local.
 #   Run "make" to build HyperRogue as ./hyperrogue.
 
 

--- a/README.md
+++ b/README.md
@@ -62,15 +62,13 @@ On Linux with apt-get:
 
 On macOS with Homebrew:
 
-```brew install sdl sdl_ttf sdl_gfx sdl_mixer glew```
-
-macOS users might also have to edit /usr/local/include/SDL/SDL_gfxPrimitives.h at line 38 to use quote include.
+```brew install sdl sdl_ttf sdl_gfx sdl_mixer glew libpng```
 
 ### Building HyperRogue from source ###
 ```
 git clone https://github.com/zenorogue/hyperrogue.git hyperrogue
 cd hyperrogue
-make
+HYPERROGUE_USE_GLEW=1 HYPERROGUE_USE_PNG=1 make
 ```
 
 The `mymake` program builds HyperRogue in parts. It takes longer than the method shown above, but it uses significantly less memory during compilation, and when you change something, `mymake` will only recompile the changed file.


### PR DESCRIPTION
HyperRogue can now be build on an Apple Silicon device, where the brew prefix is different. In addition, #332 has been fixed.  Documentation on building has been improved, especially regarding using Glew (and libpng). 

While some of these fixes could be trivially fixed for Linux, there are already PRs to do that (#333); I don't want to create a merge conflict.

Fixes: #332

- **Fix MacOS-silicon compile**
- **Update MacOS Makefile comments to match README**
- **Fix SDL include from sdl_gfx**
- **Add message about using glew and libpng to Makefile**
- **Update README.md with up-to-date build info**