### PR TITLE
Fix the build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,13 @@
 #   Run `make` to build HyperRogue as `./hyperrogue`.
 #
 # For MSYS2 and MinGW-w64:
-#   You might need to run commands such as "pacman -S mingw-w64-x86_64-SDL"
-#   to install SDL and other required libraries.
-#   Run "make" to build HyperRogue as ./hyperrogue.exe.
+#   To install SDL and other required libraries, run these commands
+#   from the MSYS2 shell:
+#       pacman -S mingw-w64-ucrt-x86_64-glew
+#       pacman -S mingw-w64-ucrt-x86_64-SDL mingw-w64-ucrt-x86_64-SDL_mixer
+#       pacman -S mingw-w64-ucrt-x86_64-SDL_ttf mingw-w64-ucrt-x86_64-SDL_gfx
+#       pacman -S make
+#   Then run "make" to build HyperRogue as ./hyperrogue.exe.
 #
 # For Ubuntu Linux:
 #   Run "sudo apt-get install libsdl-dev" to install SDL in /usr/local.
@@ -58,7 +62,7 @@ ifeq (${OS},linux)
 endif
 
 ifeq (${OS},mingw)
-  CXXFLAGS_EARLY += -DWINDOWS -mwindows -D_A_VOLID=8
+  CXXFLAGS_EARLY += -DWINDOWS -mwindows -D_A_VOLID=8 -I/ucrt64/include/SDL
   EXE_EXTENSION := .exe
   LDFLAGS_GL := -lopengl32
   LDFLAGS_GLEW := -lglew32
@@ -85,7 +89,7 @@ ifeq (${OS},osx)
 endif
 
 ifeq (${TOOLCHAIN},clang)
-  CXXFLAGS_STD = -std=c++11
+  CXXFLAGS_STD = -std=c++14
   CXXFLAGS_EARLY += -fPIC
   CXXFLAGS_EARLY += -W -Wall -Wextra -Wsuggest-override -pedantic
   CXXFLAGS_EARLY += -Wno-unused-parameter -Wno-implicit-fallthrough -Wno-maybe-uninitialized -Wno-char-subscripts -Wno-unknown-warning-option
@@ -93,7 +97,7 @@ ifeq (${TOOLCHAIN},clang)
 endif
 
 ifeq (${TOOLCHAIN},gcc)
-  CXXFLAGS_STD = -std=c++11
+  CXXFLAGS_STD = -std=c++14
   CXXFLAGS_EARLY += -fPIC
   CXXFLAGS_EARLY += -W -Wall -Wextra -pedantic
   CXXFLAGS_EARLY += -Wno-unused-parameter -Wno-implicit-fallthrough -Wno-maybe-uninitialized
@@ -101,7 +105,7 @@ ifeq (${TOOLCHAIN},gcc)
 endif
 
 ifeq (${TOOLCHAIN},mingw)
-  CXXFLAGS_STD = -std=c++11
+  CXXFLAGS_STD = -std=c++14
   CXXFLAGS_EARLY += -W -Wall -Wextra
   CXXFLAGS_EARLY += -Wno-unused-parameter -Wno-implicit-fallthrough -Wno-maybe-uninitialized
   CXXFLAGS_EARLY += -Wno-invalid-offsetof
@@ -178,7 +182,7 @@ mymake$(EXE_EXTENSION): mymake.cpp
 emscripten: hyper.html
 
 %.html %.js %.wasm: %.emscripten-sources
-	emcc -std=c++11 -O3 -s USE_ZLIB=1 -s LEGACY_GL_EMULATION=1 -s TOTAL_MEMORY=128MB hyperweb.cpp -o hyper.html
+	emcc -std=c++14 -O3 -s USE_ZLIB=1 -s LEGACY_GL_EMULATION=1 -s TOTAL_MEMORY=128MB hyperweb.cpp -o hyper.html
 
 hyper.emscripten-sources: *.cpp autohdr.h
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 # For MSYS2 and MinGW-w64:
 #   To install SDL and other required libraries, run these commands
 #   from the MSYS2 shell:
-#       pacman -S mingw-w64-ucrt-x86_64-glew
+#       pacman -S mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-glew
 #       pacman -S mingw-w64-ucrt-x86_64-SDL mingw-w64-ucrt-x86_64-SDL_mixer
 #       pacman -S mingw-w64-ucrt-x86_64-SDL_ttf mingw-w64-ucrt-x86_64-SDL_gfx
 #       pacman -S make


### PR DESCRIPTION
Explain how to install the required dev libraries for Windows.
Update C++ std to use from C++11 to C++14.
Put the MSYS2 SDL include dir in the include files path.