### PR TITLE
Check tide before drawing cells.

### DIFF
--- a/celldrawer.cpp
+++ b/celldrawer.cpp
@@ -2830,6 +2830,8 @@ void celldrawer::draw() {
 
   cells_drawn++;
 
+  checkTide(c);
+
 #if CAP_TEXTURE
   if(texture::saving) {
     texture::config.apply(c, V, 0xFFFFFFFF);

--- a/help.cpp
+++ b/help.cpp
@@ -883,7 +883,6 @@ EX void describeMouseover() {
       if(shmup::on)
         out += " (" + its(c->landparam)+")";
       else {
-        calcTidalPhase();
         bool b = c->landparam >= tide[turncount % tidalsize];
         int t = 1;
         for(; t < 1000 && b == (c->landparam >= tide[(turncount+t) % tidalsize]); t++) ;

--- a/system.cpp
+++ b/system.cpp
@@ -429,7 +429,8 @@ EX void initgame() {
     if(vid.use_smart_range == 2) vid.use_smart_range = 1;
     }
   if(!allowIncreasedSight()) vid.use_smart_range = 0;
-  callhooks(hooks_post_initgame); 
+  calcTidalPhase();
+  callhooks(hooks_post_initgame);
   }
 
 bool havesave = true;


### PR DESCRIPTION
Fixes bug where on the first turn in a plane, the ocean cells are all displayed as water at high tide and volcano cells are all displayed as lava at low tide.