### PR TITLE
Fix minor menu glitches.

### DIFF
--- a/graph.cpp
+++ b/graph.cpp
@@ -5803,8 +5803,8 @@ EX void normalscreen() {
 #if CAP_TOUR
   else if(tour::on) 
     displayButton(vid.xres-8, vid.yres-vid.fsize, XLAT("(ESC) tour menu"), SDLK_ESCAPE, 16);
-  else
 #endif
+  else
     displayButton(vid.xres-8, vid.yres-vid.fsize, XLAT("(v) menu"), 'v', 16);
   keyhandler = handleKeyNormal;
 

--- a/quit.cpp
+++ b/quit.cpp
@@ -50,7 +50,7 @@ string timeline() {
   else {
     s = XLAT("%1 turns (%2)", its(turncount), getgametime_s());
     if(display_yasc_codes)
-      s+= XLAT(" YASC code: ") + formatted_yasc_code();
+      s += XLAT(" YASC code: ") + formatted_yasc_code();
     }
   return s;
   }
@@ -332,7 +332,7 @@ EX void showGameMenu() {
 #if CAP_TOUR
     tour::on ? (canmove ? XLAT("guided tour") : XLAT("GAME OVER")) :
 #endif
-    (cheater && !autocheat)? XLAT("It is a shame to cheat!") : 
+    (cheater && !autocheat) ? XLAT("It is a shame to cheat!") :
     racing::on ? "racing mode" :
     (canmove && princess::challenge) ? XLAT("%1 Challenge", moPrincess) :
     canmove ? XLAT("Quest status") : 
@@ -445,7 +445,7 @@ EX void showGameMenu() {
   if(cheater && !autocheat) {
     dialog::addInfo(XLAT("you have cheated %1 times", its(cheater)), 0xFF2020);
     }
-  else if(!racing::on) {
+  if(!racing::on) {
     dialog::addInfo(timeline(), dialog::dialogcolor);
     }
   


### PR DESCRIPTION
Currently, if CAP_TOUR is not set then "(v) menu" is displayed unconditionally, because the "else" statement which suppresses its display when nomenukey is set is guarded by CAP_TOUR.  That "else" statement is moved outside the guard.

Currently, the "timeline" -- containing the elapsed time, turn count, and YASC code -- is not displayed if cheats are active, because it's replaced by a cheats count line.  Since these lines don't conflict and the timeline contains useful information, changed to display both.