### PR TITLE
Make option to show turns on the main screen.

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -1173,6 +1173,8 @@ EX void initConfig() {
 
   param_i(min_cells_drawn, "min_cells_drawn");
 
+  param_b(show_turns, "show_turns", false)
+  -> editable("show turn count", 'T');
   param_i(menu_darkening, "menu_darkening", 2)
   -> editable(0, 8, 1, "menu map darkening", "A larger number means darker game map in the background. Set to 8 to disable the background.", 'd')
   -> set_sets([] { dialog::bound_low(0); dialog::bound_up(8); dialog::get_di().dialogflags |= sm::DARKEN; });
@@ -2443,6 +2445,7 @@ EX void configureInterface() {
       };
     });
 
+  add_edit(show_turns);
   add_edit(menu_darkening);
   add_edit(centered_menus);
   add_edit(startanims::enabled);

--- a/graph.cpp
+++ b/graph.cpp
@@ -5672,6 +5672,7 @@ EX bool just_refreshing;
 
 EX int menu_darkening = 2;
 EX bool centered_menus = false;
+EX bool show_turns = false;
 
 EX void gamescreen() {
 
@@ -5798,7 +5799,9 @@ EX void normalscreen() {
   cmode = sm::NORMAL | sm::DOTOUR | sm::CENTER;
   if(viewdists && show_distance_lists) cmode |= sm::SIDE | sm::MAYDARK;
   gamescreen(); drawStats();
-  if(nomenukey || ISMOBILE)
+  if(show_turns)
+    displayButton(vid.xres-8, vid.yres-vid.fsize, "t:" + its(turncount), 'v', 16);
+  else if(nomenukey || ISMOBILE)
     ;
 #if CAP_TOUR
   else if(tour::on) 


### PR DESCRIPTION
"Liberal" version that shows the turncount unguarded by nomenukey and ISMOBILE.  Hopefully this means that it'll display properly on mobile, outside the map region's "DRAG" area. But this display mode is only used by the mobile builds which I don't have toolchains for, so can't test it.  :(