### PR TITLE
Select the keyboard push-subdirection with Tab.

### DIFF
--- a/control.cpp
+++ b/control.cpp
@@ -149,6 +149,7 @@ EX void movepckeydir(int d) {
   if(protect_memory()) return;
   
   movedir md = vectodir(move_destination_vec(d));
+  md.subdir = keybd_subdir ? 1 : -1;
     
   if(!canmove) movepcto(md), remission(); else movepcto(md);
   }
@@ -616,6 +617,10 @@ EX void handleKeyNormal(int sym, int uni) {
     if(needConfirmation()) 
       pushScreen(showGameMenu);
     else restart_game();
+    }
+
+  if(sym == SDLK_TAB) {
+    keybd_subdir = !keybd_subdir;
     }
 
   if(sym == SDLK_ESCAPE) {

--- a/graph.cpp
+++ b/graph.cpp
@@ -3559,8 +3559,9 @@ EX transmatrix applyDowndir(cell *c, const cellfunction& cf) {
   return ddspin180(c, patterns::downdir(c, cf));
   }
 
-void draw_movement_arrows(cell *c, const transmatrix& V, int df) {
+EX bool keybd_subdir;
 
+void draw_movement_arrows(cell *c, const transmatrix& V, int df) {
   if(viewdists) return;
   
   string keylist = "";
@@ -3590,8 +3591,8 @@ void draw_movement_arrows(cell *c, const transmatrix& V, int df) {
 
       if((c->type & 1) && (isStunnable(c->monst) || isPushable(c->wall))) {
         transmatrix Centered = rgpushxto0(unshift(tC0(cwtV)));
-        int sd = md.subdir;
-        
+        int sd = keybd_subdir ? 1 : -1;
+
         transmatrix T = iso_inverse(Centered) * rgpushxto0(Centered * tC0(V)) * lrspintox(Centered*tC0(V)) * spin(-sd * M_PI/S7) * xpush(0.2);
         
         if(vid.axes >= 5)

--- a/help.cpp
+++ b/help.cpp
@@ -259,7 +259,7 @@ string pushtext(stringpar p) {
     "\n\nNote: when pushing %the1 off a heptagonal cell, you can control the pushing direction "
     "by clicking left or right half of the heptagon.", p);
 #if !ISMOBILE
-  s += XLAT(" With the keyboard, you can rotate the view for a similar effect (Page Up/Down).");
+  s += XLAT(" With the keyboard, you can press Tab to invert the way the pushing direction leans.");
 #endif
   return s;
   }
@@ -678,7 +678,7 @@ EX string generateHelpForMonster(eMonster m) {
     }
 
   s += XLAT(minf[m].help);      
-  if(m == moPalace || m == moSkeleton)
+  if(isStunnable(m))
     s += pushtext(m);  
   if(m == moTroll) s += XLAT(trollhelp2);  
 

--- a/pcmove.cpp
+++ b/pcmove.cpp
@@ -275,7 +275,8 @@ EX bool movepcto(int d, int subdir IS(1), bool checkonly IS(false)) {
   checked_move_issue.type = miVALID;
   pcmove pcm;
   pcm.checkonly = checkonly;
-  pcm.d = d; pcm.subdir = subdir;
+  pcm.d = d;
+  pcm.subdir = subdir;
   auto b = pcm.movepcto();
   global_pushto = pcm.mip.t;
   return b;


### PR DESCRIPTION
Previously, the keyboard push-subdirection was selected irregularly based on the exact angle of the map on the screen.

Change it to be consistently clockwise or counterclockwise, switching with the Tab key.

Also, have the keyboard push-subdirection help display on all pushable monsters.  Previously, it'd only show on Palace Guards and Skeletons.