### PR TITLE
Replace `const X f()` with `X f()`. NFC.

### DIFF
--- a/binary-tiling.cpp
+++ b/binary-tiling.cpp
@@ -507,7 +507,7 @@ EX namespace bt {
         }
       }
 
-    const transmatrix iadj(heptagon *h, int dir) { heptagon *h1 = h->cmove(dir); return adj(h1, h->c.spin(dir)); }
+    transmatrix iadj(heptagon *h, int dir) { heptagon *h1 = h->cmove(dir); return adj(h1, h->c.spin(dir)); }
   
     void virtualRebase(heptagon*& base, transmatrix& at) override {
     

--- a/hyperpoint.cpp
+++ b/hyperpoint.cpp
@@ -24,7 +24,7 @@ static constexpr ld degree = A_PI / 180;
 static const ld golden_phi = (sqrt(5)+1)/2;
 static const ld log_golden_phi = log(golden_phi);
 
-constexpr ld operator"" _deg(long double deg) { return deg * A_PI / 180; }
+constexpr ld operator""_deg(long double deg) { return deg * A_PI / 180; }
 #endif
 
 eGeometry geometry;

--- a/language.cpp
+++ b/language.cpp
@@ -10,10 +10,10 @@
 #include "hyper.h"
 namespace hr {
 
-EX const string dnameof(eMonster m) { return m >= 0 && m < motypes ? minf[m].name : hr::format("[MONSTER %d]", m); }
-EX const string dnameof(eLand l) { return l >= 0 && l < landtypes ? linf[l].name : hr::format("[LAND %d]", l); }
-EX const string dnameof(eWall w) { return w >= 0 && w < walltypes ? winf[w].name : hr::format("[WALL %d]", w); }
-EX const string dnameof(eItem i) { return i >= 0 && i < ittypes ? iinf[i].name : hr::format("[ITEM %d]", i); }
+EX string dnameof(eMonster m) { return m >= 0 && m < motypes ? minf[m].name : hr::format("[MONSTER %d]", m); }
+EX string dnameof(eLand l) { return l >= 0 && l < landtypes ? linf[l].name : hr::format("[LAND %d]", l); }
+EX string dnameof(eWall w) { return w >= 0 && w < walltypes ? winf[w].name : hr::format("[WALL %d]", w); }
+EX string dnameof(eItem i) { return i >= 0 && i < ittypes ? iinf[i].name : hr::format("[ITEM %d]", i); }
 
 #if HDR
 #define NUMLAN 9


### PR DESCRIPTION
Theoretically, this improves codegen by allowing `x = f()` to move-from the returned temporary instead of requiring a copy. In these cases I don't expect any effect; it's just to keep the codebase clean.

Also change `operator"" _deg` to `operator""_deg`; the former spelling was deprecated in 2023 (but, strangely, was deprecated retroactively all the way back to C++11: see CWG2521).