### PR TITLE
Create configuration parameter for higher contrast of some terrain elements

### DIFF
--- a/celldrawer.cpp
+++ b/celldrawer.cpp
@@ -88,7 +88,7 @@ inline void drawcell(cell *c, const shiftmatrix& V) {
 static constexpr int trapcol[4] = {0x904040, 0xA02020, 0xD00000, 0x303030};
 static constexpr int terracol[8] = {0xD000, 0xE25050, 0xD0D0D0, 0x606060, 0x303030, 0x181818, 0x0080, 0x8080};
 
-EX colortable prairie_colors = { 0x402000, 0x503000 };
+EX colortable prairie_colors = { 0x102030, 0x905010 };
 EX colortable mountain_colors = { 0x181008*2, 0x181008*4 };
 EX colortable tower_colors = { 0x202010, 0x404030 };
 EX colortable westwall_colors = { 0x211F6F, 0x413F8F };

--- a/celldrawer.cpp
+++ b/celldrawer.cpp
@@ -209,10 +209,10 @@ void celldrawer::setcolors() {
       for(int a=0; a<21; a++)
         if((b >> a) & 1)
           fcol += variant::features[a].color_change;
-      if(c->wall == waAncientGrave)
+      /*if(c->wall == waAncientGrave)
         wcol = 0x080808;
       else if(c->wall == waFreshGrave)
-        wcol = 0x202020;
+        wcol = 0x202020;*/
       break;
       }
     #endif

--- a/celldrawer.cpp
+++ b/celldrawer.cpp
@@ -88,7 +88,9 @@ inline void drawcell(cell *c, const shiftmatrix& V) {
 static constexpr int trapcol[4] = {0x904040, 0xA02020, 0xD00000, 0x303030};
 static constexpr int terracol[8] = {0xD000, 0xE25050, 0xD0D0D0, 0x606060, 0x303030, 0x181818, 0x0080, 0x8080};
 
-EX colortable prairie_colors = { 0x102030, 0x905010 };
+EX colortable prairie_colors = { 0x402000, 0x503000 };
+//EX colortable prairie_colors_low_cont = { 0x402000, 0x503000 };
+//EX colortable prairie_colors_high_cont = { 0x102030, 0x905010 };
 EX colortable mountain_colors = { 0x181008*2, 0x181008*4 };
 EX colortable tower_colors = { 0x202010, 0x404030 };
 EX colortable westwall_colors = { 0x211F6F, 0x413F8F };

--- a/celldrawer.cpp
+++ b/celldrawer.cpp
@@ -209,10 +209,12 @@ void celldrawer::setcolors() {
       for(int a=0; a<21; a++)
         if((b >> a) & 1)
           fcol += variant::features[a].color_change;
-      /*if(c->wall == waAncientGrave)
-        wcol = 0x080808;
-      else if(c->wall == waFreshGrave)
-        wcol = 0x202020;*/
+      if(!higher_contrast) {
+        if(c->wall == waAncientGrave)
+          wcol = 0x080808;
+        else if(c->wall == waFreshGrave)
+          wcol = 0x202020;
+        }
       break;
       }
     #endif

--- a/celldrawer.cpp
+++ b/celldrawer.cpp
@@ -510,8 +510,8 @@ void celldrawer::setcolors() {
         if(c->monst == moFriendlyGhost) 
           fcol = gradient(fcol, fghostcolor(c), 0, .5, 1);
     
-        if(c->wall == waSmallTree) wcol = 0x004000;
-        else if(c->wall == waBigTree) wcol = 0x008000;
+        /* if(c->wall == waSmallTree) wcol = 0x006000;
+        else if(c->wall == waBigTree) wcol = 0x008000; */
         }
     }
   

--- a/celldrawer.cpp
+++ b/celldrawer.cpp
@@ -510,8 +510,10 @@ void celldrawer::setcolors() {
         if(c->monst == moFriendlyGhost) 
           fcol = gradient(fcol, fghostcolor(c), 0, .5, 1);
     
-        /* if(c->wall == waSmallTree) wcol = 0x006000;
-        else if(c->wall == waBigTree) wcol = 0x008000; */
+        if (!higher_contrast) {
+          if(c->wall == waSmallTree) wcol = 0x004000;
+          else if(c->wall == waBigTree) wcol = 0x008000;
+          }
         }
     }
   

--- a/celldrawer.cpp
+++ b/celldrawer.cpp
@@ -89,8 +89,7 @@ static constexpr int trapcol[4] = {0x904040, 0xA02020, 0xD00000, 0x303030};
 static constexpr int terracol[8] = {0xD000, 0xE25050, 0xD0D0D0, 0x606060, 0x303030, 0x181818, 0x0080, 0x8080};
 
 EX colortable prairie_colors = { 0x402000, 0x503000 };
-//EX colortable prairie_colors_low_cont = { 0x402000, 0x503000 };
-//EX colortable prairie_colors_high_cont = { 0x102030, 0x905010 };
+EX colortable prairie_colors_high_cont = { 0x102030, 0x905010 };
 EX colortable mountain_colors = { 0x181008*2, 0x181008*4 };
 EX colortable tower_colors = { 0x202010, 0x404030 };
 EX colortable westwall_colors = { 0x211F6F, 0x413F8F };
@@ -404,7 +403,8 @@ void celldrawer::setcolors() {
     #if CAP_FIELD
     case laPrairie:
       if(prairie::isriver(c)) {
-        fcol = get_color_auto3(prairie::get_val(c), prairie_colors);
+        fcol = get_color_auto3(prairie::get_val(c),
+                  higher_contrast ? prairie_colors_high_cont : prairie_colors);
         }
       else {
         fcol = 0x004000 + 0x001000 * c->LHU.fi.walldist;

--- a/config.cpp
+++ b/config.cpp
@@ -29,6 +29,8 @@ EX bool linked_consequence;
 
 EX bool hr_hud_enabled = true;
 
+EX bool higher_contrast = false;
+
 EX void adjust_linked() {
   indenter ind(2);
   geom3::invalid = "";
@@ -1110,6 +1112,10 @@ EX void initConfig() {
      "Enable this for a full dialog when editing some on/off settings (otherwise, the dialog is not shown, we just switch). "
      "This lets you see an explanation of what the setting does. "
      "You can also press ALT while changing such settings.");
+
+  param_b(higher_contrast, "higher_contrast")
+  ->editable("use higher contrast", 'h')
+  ->help("Use higher contrast for some terrain elements.");
 
   param_b(vid.grid, "grid");
   param_b(models::desitter_projections, "desitter_projections", false);
@@ -3720,6 +3726,7 @@ EX void show_color_dialog() {
 
   dialog::addColorItem(XLAT("dialogs"), addalpha(dialog::dialogcolor), 'd');
   dialog::add_action([] () { dialog::openColorDialog(dialog::dialogcolor); dialog::colorAlpha = false; dialog::get_di().dialogflags |= sm::SIDE; });
+  dialog::addBoolItem_action(XLAT("higher contrast"), higher_contrast, 'h');
 
   dialog::addBreak(50);
   if(specialland == laCanvas && ccolor::which->ctab.size()) {


### PR DESCRIPTION
Some terrain elements have un-editable colors, but are shown in a moderately low-contrast manner.  This has sparked occasional requests that their visual contrast be increased.  This patch adds a parameter for higher contrast color display.  When set, the darkening of trees in the Haunted Woods is suppressed, as is the darkening of graves in the Irradiated Field, and the bull lanes in Prairie have their contrast increased.  (The colors of the bull lanes are editable, but those edits do not persist.  That's probably a bug in config file handling.)