### PR TITLE
Increase waRed contrast with EC floor when higher_contrast set

### DIFF
--- a/celldrawer.cpp
+++ b/celldrawer.cpp
@@ -116,7 +116,27 @@ void celldrawer::addaura() {
 /* Eclectic City's version of Red Rock is of slightly different color, */
 /* to make it different from hot cells */
 void eclectic_red(color_t& col) {
-  part(col, 0) = part(col, 2) * 3 / 4;
+  if (!higher_contrast) {
+    part(col, 0) = part(col, 2) * 3 / 4;
+    } else {
+    auto d = (part(col, 0) + part(col, 1) + part(col, 2));
+    auto t = part(col, 0);
+    part(col, 0) = part(col, 1);
+    part(col, 1) = part(col, 2);
+    part(col, 2) = t + d/3;
+    //swap(part(col, 0), part(col, 1));
+    /* auto h = part(col, 0) / 2;
+    part(col, 0) -= h;
+    part(col, 1) += h;
+    part(col, 2) += h / 2; */
+    /* part(col, 0) += part(col, 0) / 4;
+    part(col, 1) += part(col, 1) + 16;
+    part(col, 2) += part(col, 2) / 2 + 8; */
+
+    /* part(col, 0) += d;
+    part(col, 1) += 3*d;
+    part(col, 2) += 2*d; */
+    }
   }
 
 constexpr ld spinspeed = .75 / M_PI;
@@ -716,7 +736,10 @@ int celldrawer::getSnakelevColor(int i, int last) {
     if(c->land == laEclectic)
       eclectic_red(col);
     }
-  return darkena(col, fd, 0xFF);
+  if (!higher_contrast)
+    return darkena(col, fd, 0xFF);
+  else
+    return darkena(col, 0, 0xFF);
   }
 
 void celldrawer::draw_wallshadow() {

--- a/celldrawer.cpp
+++ b/celldrawer.cpp
@@ -119,23 +119,11 @@ void eclectic_red(color_t& col) {
   if (!higher_contrast) {
     part(col, 0) = part(col, 2) * 3 / 4;
     } else {
-    auto d = (part(col, 0) + part(col, 1) + part(col, 2));
+    auto v = part(col, 0) + part(col, 1) + part(col, 2);
     auto t = part(col, 0);
     part(col, 0) = part(col, 1);
     part(col, 1) = part(col, 2);
-    part(col, 2) = t + d/3;
-    //swap(part(col, 0), part(col, 1));
-    /* auto h = part(col, 0) / 2;
-    part(col, 0) -= h;
-    part(col, 1) += h;
-    part(col, 2) += h / 2; */
-    /* part(col, 0) += part(col, 0) / 4;
-    part(col, 1) += part(col, 1) + 16;
-    part(col, 2) += part(col, 2) / 2 + 8; */
-
-    /* part(col, 0) += d;
-    part(col, 1) += 3*d;
-    part(col, 2) += 2*d; */
+    part(col, 2) = t + v/3;
     }
   }
 

--- a/colors.cpp
+++ b/colors.cpp
@@ -55,6 +55,20 @@ EX int darkenedby(int c, int lev) {
   return c;
   }
 
+EX color_t lightena3(color_t c, int lev, int a) {
+  return (lightenedby(c, lev) << 8) + a;
+  }
+
+EX color_t lightena(color_t c, int lev, int a) {
+  return lightena3(c, lev, GDIM == 3 ? 255 : a);
+  }
+
+EX int lightenedby(int c, int lev) {
+  for(int i=0; i<lev; i++)
+    c = ((c | 0x010101) << 1);
+  return c;
+  }
+
 bool fading = false;
 
 ld fadeout = 1;

--- a/colors.cpp
+++ b/colors.cpp
@@ -55,20 +55,6 @@ EX int darkenedby(int c, int lev) {
   return c;
   }
 
-EX color_t lightena3(color_t c, int lev, int a) {
-  return (lightenedby(c, lev) << 8) + a;
-  }
-
-EX color_t lightena(color_t c, int lev, int a) {
-  return lightena3(c, lev, GDIM == 3 ? 255 : a);
-  }
-
-EX int lightenedby(int c, int lev) {
-  for(int i=0; i<lev; i++)
-    c = ((c | 0x010101) << 1);
-  return c;
-  }
-
 bool fading = false;
 
 ld fadeout = 1;


### PR DESCRIPTION
When higher_contrast is set, change the waRed[123] walls to be green-ish instead of purple-ish in Eclectic City, for greater contrast with EC's purple-ish floor.

The logic for selecting waRed's colors is strange, and this delta is from me futzing around with the code until I got it to look decent, instead of getting an understanding of the waRed color logic and applying that knowledge.  I expected the motivation behind the complicated waRed color behavior to be making the floor:wall color relationships match those of RRV.  But this seems refuted by observing that RRV and CR1 have nearly identical floor colors yet waRed appears very differently in them.