### PR TITLE
util: Parse token as color, not overall string.

### DIFF
--- a/util.cpp
+++ b/util.cpp
@@ -615,17 +615,17 @@ color_t exp_parser::parsecolor(int prio) {
   string token = next_token();
   if(params.count(token)) return (color_t) real(params[token]->get_cld());
 
-  auto p = find_color_by_name(s);
+  auto p = find_color_by_name(token);
   if(p) return (p->second << 8) | 0xFF;
 
   color_t res;
-  if(s.size() == 6) {
-    int qty = sscanf(s.c_str(), "%x", &res);
+  if(token.size() == 6) {
+    int qty = sscanf(token.c_str(), "%x", &res);
     if(qty == 0) throw hr_parse_exception("color parse error");
     return res * 256 + 0xFF;
     }
-  else if(s.size() == 8) {
-    int qty = sscanf(s.c_str(), "%x", &res);
+  else if(token.size() == 8) {
+    int qty = sscanf(token.c_str(), "%x", &res);
     if(qty == 0) throw hr_parse_exception("color parse error");
     return res;
    }


### PR DESCRIPTION
HyperRogue wrote something like this in my ini when I tried to edit Lost Mountain colors:
```
color_mountain=FF8040,E07038,C06030
```
It crashes when trying to load this.

If I change it to something like
```
color_mountain=rgb(1,0.5,0.25),rgb(0.9,0.45,0.225),rgb(0.8,0.4,0.2)
```
that loads correctly.

It seems that parsecolor doesn't work correctly for parsing a substring when it's the 6-digit or 8-digit hex format, because it checks the overall string being parsed, not the token it just consumed. As far as I can tell, the remaining types that can be consumed at this point should always be one token.
