### PR TITLE
Make the Orb of Safety in the Haunted Woods forbidden instead of dangerous

### DIFF
--- a/orbgen.cpp
+++ b/orbgen.cpp
@@ -304,11 +304,14 @@ EX eOrbLandRelation getOLR(eItem it, eLand l) {
     if(it == itOrbDragon || it == itOrbFire || it == itOrbFlash || it == itOrbLightning)
       return olrDangerous;
   
-  if(it == itOrbSafety)
+  if(it == itOrbSafety) {
     if(l == laCaves || l == laLivefjord || l == laRedRock || l == laCocytus || l == laHell ||
-      l == laDesert || l == laAlchemist || l == laDeadCaves || l == laMinefield || isHaunted(l) ||
+      l == laDesert || l == laAlchemist || l == laDeadCaves || l == laMinefield ||
       l == laDragon || l == laWet || l == laCursed)
       return olrDangerous;
+    if(isHaunted(l))
+      return olrForbidden;
+  }
     
   if(it == itOrbMatter)
     if(among(l, laCaves, laEmerald, laAlchemist, laCaribbean, laMinefield, laCocytus, laWestWall))


### PR DESCRIPTION
If you somehow get an Orb of Safety in the Haunted Woods (e.g., by bringing in a Water Elemental followed by a Pirate in a boat with one), using it is perfectly safe and will put you in the Graveyard.