### PR TITLE
Remove incorrect message about saving in Archimedean

### DIFF
--- a/quit.cpp
+++ b/quit.cpp
@@ -10,7 +10,7 @@ namespace hr {
 
 EX bool quitsaves() { 
   if(casual) return false;
-  return (items[itOrbSafety] && CAP_SAVE && !arcm::in()); 
+  return (items[itOrbSafety] && CAP_SAVE);
   }
 
 EX bool needConfirmationEvenIfSaved() {


### PR DESCRIPTION
Commit 1c4aa5ba851e disabled saving in Archimedean and added a warning that quitting wouldn't save. Commit 3505f17460f1 re-enabled saving in Archimedean, but left the warning. Remove it now.