### PR TITLE
Make the Orb of Earth/Earth Elemental not remove limestone walls in Irradiated Field and the Mercury River subland, and make OoEarth create a trail of mercury in the mercury river subland

### DIFF
--- a/mapeffects.cpp
+++ b/mapeffects.cpp
@@ -160,7 +160,7 @@ EX bool earthFloor(cell *c) {
   if(c->monst) return false;
   if(c->wall == waDeadwall) { c->wall = waDeadfloor; return true; }
   if(c->wall == waDune) { c->wall = waNone; return true; }
-  if(c->wall == waStone && c->land != laTerracotta) { c->wall = waNone; return true; }
+  if(c->wall == waStone && !among(c->land, laTerracotta, laMercuryRiver, laVariant)) { c->wall = waNone; return true; }
   if(c->wall == waAncientGrave || c->wall == waFreshGrave || c->wall == waRuinWall) {
     c->wall = waNone;
     return true;
@@ -259,11 +259,11 @@ EX bool earthWall(cell *c) {
     c->wall = waChasm;
     return true;
     }
-  if(c->wall == waNone && c->land == laTerracotta) {
+  if(c->wall == waNone && among(c->land, laTerracotta, laMercuryRiver) {
     c->wall = waMercury;
     return true;
     }
-  if(c->wall == waArrowTrap && c->land == laTerracotta) {
+  if(c->wall == waArrowTrap && among(c->land, laTerracotta, laMercuryRiver)) {
     destroyTrapsOn(c);
     c->wall = waMercury;
     return true;

--- a/mapeffects.cpp
+++ b/mapeffects.cpp
@@ -259,7 +259,7 @@ EX bool earthWall(cell *c) {
     c->wall = waChasm;
     return true;
     }
-  if(c->wall == waNone && among(c->land, laTerracotta, laMercuryRiver) {
+  if(c->wall == waNone && among(c->land, laTerracotta, laMercuryRiver)) {
     c->wall = waMercury;
     return true;
     }


### PR DESCRIPTION
The Orb of Earth in the Terracotta Army can't remove limestone walls, which I assume is because of the arrow traps. If that's true, then the Orb of Earth being able to remove limestone walls in Irradiated Field would be unintentional. I also prevented the Orb of Earth from removing limestone walls in the Mercury River subland, since I think I have seen limestone walls on the bridges before, though I don't have proof of that.

And I'm pretty sure the Orb of Earth not leaving mercury on Mercury River subland cells that the player steps off of is unintentional.