### PR TITLE
Stop WFC generation from spilling 1 tile into neighboring lands

### DIFF
--- a/wfcgen.cpp
+++ b/wfcgen.cpp
@@ -220,7 +220,7 @@ EX void invoke() {
         c->wall = p.first[0];
         c->wparam = p.first[0];
         forCellEx(c1, c) {
-          if(c1->wall != waBarrier) 
+          if(c1->wall != waBarrier && c1->land == c->land)
             c1->wparam = c1->wall = p.first[idx];
           idx++;
           }


### PR DESCRIPTION
Hopefully this will stop Rosebushes from appearing right outside Eclectic City