### PR TITLE
Make the "switch ghost timer" cheat display shmup::curtime instead of the turn/knives thrown count in shmup

### DIFF
--- a/debug.cpp
+++ b/debug.cpp
@@ -246,8 +246,14 @@ vector<cheatkey> cheats = {
   cheatkey{'G'-64, "switch ghost timer", [] {
     timerghost = !timerghost;
     cheater++; 
-    addMessage(XLAT("turn count = %1 last exploration = %2 ghost timer = %3",
-      its(turncount), its(lastexplore), ONOFF(timerghost)));
+		if(shmup::on) {
+			addMessage(XLAT("in-game time = %1 last exploration = %2 ghost timer = %3",
+				its(shmup::curtime), its(lastexplore), ONOFF(timerghost)));
+			}
+		else {
+			addMessage(XLAT("turn count = %1 last exploration = %2 ghost timer = %3",
+				its(turncount), its(lastexplore), ONOFF(timerghost)));
+			}
     }},
   cheatkey{'G', "edit cell values", push_debug_screen},
   cheatkey{'L'-64, "cell info", [] {


### PR DESCRIPTION
I used "in-game time" since I thought that just using "time" would imply that it's displaying the timer that's to the right of the turn count/knives thrown counter in the main menu, but I'm not sure if "in-game time" is the best description for shmup::curtime.