### PR TITLE
Fix edge cases in Hell/CR3 unlock

### DIFF
--- a/landlock.cpp
+++ b/landlock.cpp
@@ -222,13 +222,15 @@ EX bool landUnlockedRPM(eLand n) {
 
 EX int lands_for_hell() {
   int desired = casual ? 40 : 9;
-  int available = std::count_if(land_over.begin(), land_over.end(), [] (eLand l) { return !among(l, laHell, laCocytus, laPower) && !isCrossroads(l) && isLandIngame(l); });
+  int available = std::count_if(land_over.begin(), land_over.end(), [] (eLand l) { return !among(l, laHell, laCocytus, laPower) && !isCrossroads(l) && iinf[linf[l].treasure].itemclass == IC_TREASURE && isLandIngame(l); });
+  if(isLandIngame(laMirror) && isLandIngame(laMirrorOld)) --available;
   return min(desired, available);
   }
 
 EX int lands_for_cr3() {
   int desired = casual ? 20 : 9;
-  int available = std::count_if(land_over.begin(), land_over.end(), [] (eLand l) { return !isCrossroads(l) && isLandIngame(l); });
+  int available = std::count_if(land_over.begin(), land_over.end(), [] (eLand l) { return !isCrossroads(l) && iinf[linf[l].treasure].itemclass == IC_TREASURE && isLandIngame(l); });
+  if(isLandIngame(laMirror) && isLandIngame(laMirrorOld)) --available;
   return min(desired, available);
   }
 


### PR DESCRIPTION
If Mirror Land and Hall of Mirrors are both in-game, only one counts, and Camelot, Palace Quest, and Cellular Automaton don't count at all.