### PR TITLE
Rework removed tiles in Crystal World

### DIFF
--- a/help.cpp
+++ b/help.cpp
@@ -1030,7 +1030,7 @@ EX void describeMouseover() {
       }
     #endif
       
-    if(c->wall && !(c->wall == waChasm && c->land == laDual && ctof(c)) &&
+    if(c->wall && !(c->land == laDual && pseudohept(c)) &&
       !(c->land == laMemory) &&
       !((c->wall == waFloorA || c->wall == waFloorB) && c->item)) { 
 

--- a/passable.cpp
+++ b/passable.cpp
@@ -143,6 +143,8 @@ EX bool anti_alchemy(cell *w, cell *from) {
 EX bool passable(cell *w, cell *from, flagtype flags) {
   bool vrevdir = bool(flags&P_VOID);
 
+  if(w->land == laDual && pseudohept(w) && !F(P_BULLET)) return false;
+
   if(from && from != w && nonAdjacent(from, w) && !F(P_IGNORE37 | P_BULLET)) return false;
   
   if((isWateryOrBoat(w) || w->wall == waShallow) && F(P_WATERCURSE))
@@ -169,7 +171,6 @@ EX bool passable(cell *w, cell *from, flagtype flags) {
     if(airdist(w) < 3) return false;
     if(againstWind(w,from)) return false;
     if(isGravityLand(w)) return false;
-    if(w->wall == waChasm && w->land == laDual) return false;
     }
 
   if(from && strictlyAgainstGravity(w, from, vrevdir, flags)

--- a/pcmove.cpp
+++ b/pcmove.cpp
@@ -1136,7 +1136,7 @@ void pcmove::tell_why_impassable() {
     if(vmsg(miRESTRICTED, siGRAVITY, c2, moNone))
       addMessage(XLAT("Gravity does not allow this!"));
     }
-  else if(c2->wall == waChasm && c2->land == laDual) {
+  else if(c2->land == laDual && pseudohept(c2)) {
     if(vmsg(miRESTRICTED, siWALL, c2, moNone))
       addMessage(XLAT("You cannot move there!"));
     }


### PR DESCRIPTION
They're now treated specially in passable, so even flying/aethereal/etc. beings can't occupy them, since they're not supposed to exist at all. This also fixes a bug where trying to move onto chasms that used to be trapdoors in Crystal World would give the generic "You cannot move there!" message instead of the correct "You cannot move through the chasm!" message, and a bug where things like Slime Beasts could make them walkable.