### PR TITLE
Fix crash when Orbs of Choice, Space, and Safety interact

### DIFF
--- a/orbs.cpp
+++ b/orbs.cpp
@@ -865,9 +865,11 @@ void telekinesis(cell *dest) {
   eItem it = cwt.at->item;
   bool saf = it == itOrbSafety;
   collectItem(cwt.at, cwt.at, true);
-  if(cwt.at->item == it)
+  if(saf)
+    ;
+  else if(cwt.at->item == it)
     animateMovement(match(dest, cwt.at), LAYER_BOAT);
-  else if(!saf)
+  else
     animate_item_throw(dest, cwt.at, it);
 
   useupOrb(itOrbSpace, cost.first);


### PR DESCRIPTION
When grabbing an Orb of Safety across lands with Orb of Space while Orb of Choice is active, a "HEPTAGONAL RULE MISSING" message would print and the game would exit. Fix it by not running the animation in this case.