### PR TITLE
Fix Free Fall crashing in horodisk land structure

### DIFF
--- a/complex2.cpp
+++ b/complex2.cpp
@@ -224,7 +224,7 @@ EX namespace westwall {
   void build(vector<cell*>& whirlline, int d) {
     again: 
     cell *at = whirlline[isize(whirlline)-1];
-    cell *prev = whirlline[isize(whirlline)-2];
+    cell *prev = isize(whirlline) >= 2 ? whirlline[isize(whirlline)-2] : NULL;
     if(looped(whirlline)) return;
     for(int i=0; i<at->type; i++) 
       if(at->move(i) && coastvalEdge1(at->move(i)) == d && at->move(i) != prev) {


### PR DESCRIPTION
It still doesn't work completely right (in particular, you'll get the "warning: a looped line" message, and gravity will point the wrong way on some of the outermost tiles), but this is way better than the whole game crashing whenever you get near the land at all.