### PR TITLE
Orb of the Fish is not useless in Cursed Canyon

### DIFF
--- a/orbgen.cpp
+++ b/orbgen.cpp
@@ -370,7 +370,7 @@ EX eOrbLandRelation getOLR(eItem it, eLand l) {
   if(it == itOrbSword && l == laBurial)
     return olrAlways;
     
-  if(it == itOrbFish && !among(l, laOcean, laLivefjord, laWhirlpool, laCamelot, laTortoise, laWarpCoast, laWarpSea, laCocytus, laBrownian, laVariant, laWet, laFrog))
+  if(it == itOrbFish && !among(l, laOcean, laLivefjord, laWhirlpool, laCamelot, laTortoise, laWarpCoast, laWarpSea, laCocytus, laBrownian, laVariant, laWet, laFrog, laCursed))
     return olrUseless;
 
   if(it == itOrbDomination && l != laOcean && l != laRedRock && l != laDesert &&


### PR DESCRIPTION
Not completely useless, although it's dangerous since Curse of Water takes precedence over Orb of the Fish.